### PR TITLE
[JXD-206] Автоматический поиск датчиков температуры dallas searcher

### DIFF
--- a/esphome/components/dallas_temp_searcher/__init__.py
+++ b/esphome/components/dallas_temp_searcher/__init__.py
@@ -1,0 +1,24 @@
+import esphome.codegen as cg
+from esphome.components import one_wire
+import esphome.config_validation as cv
+from esphome.const import CONF_ID, CONF_UPDATE_INTERVAL
+
+AUTO_LOAD = ["dallas_temp"]
+
+dallas_temp_searcher_ns = cg.esphome_ns.namespace("dallas_temp_searcher")
+DallasTempSearcherComponent = dallas_temp_searcher_ns.class_(
+    "DallasTemperatureSearcher", cg.Component
+)
+
+CONFIG_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(): cv.declare_id(DallasTempSearcherComponent),
+        cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.update_interval,
+    }
+).extend(one_wire.one_wire_device_schema())
+
+
+async def to_code(config):
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)
+    await one_wire.register_one_wire_device(var, config)

--- a/esphome/components/dallas_temp_searcher/__init__.py
+++ b/esphome/components/dallas_temp_searcher/__init__.py
@@ -19,14 +19,36 @@ SEARCH_MODE = {
     "address_map": search_mode.ADDRESS_MAP,
 }
 
-CONFIG_SCHEMA = cv.Schema(
-    {
-        cv.GenerateID(): cv.declare_id(DallasTempSearcherComponent),
-        cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.update_interval,
-        cv.Optional(CONF_MAX_SENSORS_NUM, default=6): cv.int_range(0, 32),
-        cv.Optional(CONF_MODE, default="all"): cv.enum(SEARCH_MODE, lower=True),
-    }
-).extend(one_wire.one_wire_device_schema())
+MAX_SENSOR_NUM_SCHEMA = cv.All(
+    cv.Schema(
+        {cv.Required(CONF_MAX_SENSORS_NUM): cv.int_range(0, 32)}, extra=cv.ALLOW_EXTRA
+    )
+)
+
+
+def check_mode(config):
+    if CONF_MODE in config:
+        if config[CONF_MODE] == "address_map":
+            MAX_SENSOR_NUM_SCHEMA(config)
+        elif config[CONF_MODE] == "all":
+            if CONF_MAX_SENSORS_NUM in config:
+                raise cv.Invalid(
+                    f"{CONF_MAX_SENSORS_NUM} param is needed only in address_map mode"
+                )
+    return config
+
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(DallasTempSearcherComponent),
+            cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.update_interval,
+            cv.Optional(CONF_MODE, default="all"): cv.enum(SEARCH_MODE, lower=True),
+            cv.Optional(CONF_MAX_SENSORS_NUM): cv.int_,
+        }
+    ).extend(one_wire.one_wire_device_schema()),
+    check_mode,
+)
 
 
 async def to_code(config):
@@ -34,5 +56,6 @@ async def to_code(config):
     await cg.register_component(var, config)
     await one_wire.register_one_wire_device(var, config)
 
-    cg.add(var.set_max_sensors_num(config[CONF_MAX_SENSORS_NUM]))
+    if CONF_MAX_SENSORS_NUM in config:
+        cg.add(var.set_max_sensors_num(config[CONF_MAX_SENSORS_NUM]))
     cg.add(var.set_search_mode(config[CONF_MODE]))

--- a/esphome/components/dallas_temp_searcher/__init__.py
+++ b/esphome/components/dallas_temp_searcher/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 from esphome.components import one_wire
 import esphome.config_validation as cv
-from esphome.const import CONF_ID, CONF_UPDATE_INTERVAL
+from esphome.const import CONF_ID, CONF_MODE, CONF_UPDATE_INTERVAL
 
 AUTO_LOAD = ["dallas_temp"]
 
@@ -10,10 +10,21 @@ DallasTempSearcherComponent = dallas_temp_searcher_ns.class_(
     "DallasTemperatureSearcher", cg.Component
 )
 
+CONF_MAX_SENSORS_NUM = "maximum_sensors"
+
+search_mode = dallas_temp_searcher_ns.enum("SearchMode", is_class=True)
+
+SEARCH_MODE = {
+    "all": search_mode.ALL,
+    "address_map": search_mode.ADDRESS_MAP,
+}
+
 CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(): cv.declare_id(DallasTempSearcherComponent),
         cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.update_interval,
+        cv.Optional(CONF_MAX_SENSORS_NUM, default=6): cv.int_range(0, 32),
+        cv.Optional(CONF_MODE, default="all"): cv.enum(SEARCH_MODE, lower=True),
     }
 ).extend(one_wire.one_wire_device_schema())
 
@@ -22,3 +33,6 @@ async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
     await one_wire.register_one_wire_device(var, config)
+
+    cg.add(var.set_max_sensors_num(config[CONF_MAX_SENSORS_NUM]))
+    cg.add(var.set_search_mode(config[CONF_MODE]))

--- a/esphome/components/dallas_temp_searcher/__init__.py
+++ b/esphome/components/dallas_temp_searcher/__init__.py
@@ -10,7 +10,7 @@ DallasTempSearcherComponent = dallas_temp_searcher_ns.class_(
     "DallasTemperatureSearcher", cg.Component
 )
 
-CONF_MAX_SENSORS_NUM = "maximum_sensors"
+CONF_MAX_SENSORS_NUM = "max_sensors_num"
 
 search_mode = dallas_temp_searcher_ns.enum("SearchMode", is_class=True)
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 #include "esphome/core/helpers.h"
 #include "esphome/core/application.h"
-#include <string.h>
+#include <cstring>
 
 namespace esphome {
 namespace dallas_temp_searcher {
@@ -18,27 +18,27 @@ void DallasTemperatureSearcher::setup() {
   this->sensors_params_.reserve(addresses.size());
   this->sensors_.reserve(addresses.size());
 
-  char string_buff[32];
+  const size_t string_buffer_size = 32;
+  char string_buff[string_buffer_size];
 
-  for (size_t i = 0; i < addresses.size(); i++) {
-    auto sensor = new dallas_temp::DallasTemperatureSensor();
+  for (const uint64_t &address : addresses) {
+    auto *sensor = new dallas_temp::DallasTemperatureSensor();
     EntityBaseInfo entity_base_info;
     sensor->set_one_wire_bus(bus_);
 
-    const uint64_t &address = addresses[i];
     std::string address_str = format_hex(address);
 
     strcpy(string_buff, "Temp Sensor 0x");
-    strcat(string_buff, address_str.c_str());
+    strlcat(string_buff, address_str.c_str(), string_buffer_size);
     entity_base_info.name = string_buff;
 
     strcpy(string_buff, "ts_0x");
-    strcat(string_buff, address_str.c_str());
+    strlcat(string_buff, address_str.c_str(), string_buffer_size);
     entity_base_info.object_id = string_buff;
 
     sensor->set_name(entity_base_info.name.c_str());
     sensor->set_object_id(entity_base_info.object_id.c_str());
-    sensor->set_address(addresses[i]);
+    sensor->set_address(address);
     set_default_parameters_(sensor);
 
     this->sensors_.push_back(sensor);
@@ -52,7 +52,7 @@ void DallasTemperatureSearcher::setup() {
 void DallasTemperatureSearcher::dump_config() {
   ESP_LOGCONFIG(TAG, "Dallas sensor searcher:");
   for (dallas_temp::DallasTemperatureSensor *sensor : this->sensors_) {
-    ESP_LOGCONFIG(TAG, "  Added %s", sensor->get_name());
+    ESP_LOGCONFIG(TAG, "  Added %s", sensor->get_name().c_str());
   }
 }
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -18,31 +18,10 @@ void DallasTemperatureSearcher::setup() {
   this->sensors_params_.reserve(addresses.size());
   this->sensors_.reserve(addresses.size());
 
-  const size_t string_buffer_size = 32;
-  char string_buff[string_buffer_size];
-
   for (const uint64_t &address : addresses) {
-    auto *sensor = new dallas_temp::DallasTemperatureSensor();
-    EntityBaseInfo entity_base_info;
-    sensor->set_one_wire_bus(bus_);
-
-    std::string address_str = format_hex(address);
-
-    strcpy(string_buff, "Temp Sensor 0x");
-    strlcat(string_buff, address_str.c_str(), string_buffer_size);
-    entity_base_info.name = string_buff;
-
-    strcpy(string_buff, "ts_0x");
-    strlcat(string_buff, address_str.c_str(), string_buffer_size);
-    entity_base_info.object_id = string_buff;
-
-    sensor->set_name(entity_base_info.name.c_str());
-    sensor->set_object_id(entity_base_info.object_id.c_str());
-    sensor->set_address(address);
-    set_default_parameters_(sensor);
+    dallas_temp::DallasTemperatureSensor *sensor = make_sensor_(address);
 
     this->sensors_.push_back(sensor);
-    this->sensors_params_.push_back(std::move(entity_base_info));
 
     App.register_sensor(sensor);
     App.register_component(sensor);
@@ -65,6 +44,33 @@ void DallasTemperatureSearcher::set_default_parameters_(dallas_temp::DallasTempe
   sensor->set_update_interval(this->update_interval_ms_);
   sensor->set_component_source("dallas_temp.sensor");
   sensor->set_resolution(12);
+}
+
+dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_(const uint64_t &address) {
+  const size_t string_buffer_size = 32;
+  char string_buff[string_buffer_size];
+
+  auto *sensor = new dallas_temp::DallasTemperatureSensor();
+  EntityBaseInfo entity_base_info;
+  sensor->set_one_wire_bus(bus_);
+
+  std::string address_str = format_hex(address);
+
+  strcpy(string_buff, "Temp Sensor 0x");
+  strlcat(string_buff, address_str.c_str(), string_buffer_size);
+  entity_base_info.name = string_buff;
+
+  strcpy(string_buff, "ts_0x");
+  strlcat(string_buff, address_str.c_str(), string_buffer_size);
+  entity_base_info.object_id = string_buff;
+
+  sensor->set_name(entity_base_info.name.c_str());
+  sensor->set_object_id(entity_base_info.object_id.c_str());
+  sensor->set_address(address);
+  set_default_parameters_(sensor);
+
+  this->sensors_params_.push_back(std::move(entity_base_info));
+  return sensor;
 }
 
 }  // namespace dallas_temp_searcher

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -12,7 +12,7 @@ static const char *const TAG = "dallas.temp.searcher";
 void DallasTemperatureSearcher::setup() {
   if (this->bus_ == nullptr)
     return;
-  ESP_LOGCONFIG(TAG, "Dallas sensor searcher started");
+
   const std::vector<uint64_t> &addresses = this->bus_->get_devices();
 
   this->sensors_params_.reserve(addresses.size());
@@ -31,7 +31,6 @@ void DallasTemperatureSearcher::setup() {
     strcpy(string_buff, "Temp Sensor 0x");
     strcat(string_buff, address_str.c_str());
     entity_base_info.name = string_buff;
-    ESP_LOGCONFIG(TAG, "Added %s", string_buff);
 
     strcpy(string_buff, "ts_0x");
     strcat(string_buff, address_str.c_str());
@@ -47,6 +46,13 @@ void DallasTemperatureSearcher::setup() {
 
     App.register_sensor(sensor);
     App.register_component(sensor);
+  }
+}
+
+void DallasTemperatureSearcher::dump_config() {
+  ESP_LOGCONFIG(TAG, "Dallas sensor searcher:");
+  for (dallas_temp::DallasTemperatureSensor *sensor : this->sensors_) {
+    ESP_LOGCONFIG(TAG, "  Added %s", sensor->get_name());
   }
 }
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -1,0 +1,65 @@
+#include "dallas_temp_searcher.h"
+#include "esphome/core/log.h"
+#include "esphome/core/helpers.h"
+#include "esphome/core/application.h"
+#include <string.h>
+
+namespace esphome {
+namespace dallas_temp_searcher {
+
+static const char *const TAG = "dallas.temp.searcher";
+
+void DallasTemperatureSearcher::setup() {
+  if (this->bus_ == nullptr)
+    return;
+  ESP_LOGCONFIG(TAG, "Dallas sensor searcher started");
+  const std::vector<uint64_t> &addresses = this->bus_->get_devices();
+
+  this->sensors_params_.reserve(addresses.size());
+  this->sensors_.reserve(addresses.size());
+
+  char string_buff[32];
+
+  for (size_t i = 0; i < addresses.size(); i++) {
+    auto sensor = new dallas_temp::DallasTemperatureSensor();
+    EntityBaseInfo entity_base_info;
+    sensor->set_one_wire_bus(bus_);
+
+    const uint64_t &address = addresses[i];
+    std::string address_str = format_hex(address);
+
+    strcpy(string_buff, "Temp Sensor 0x");
+    strcat(string_buff, address_str.c_str());
+    entity_base_info.name = string_buff;
+    ESP_LOGCONFIG(TAG, "Added %s", string_buff);
+
+    strcpy(string_buff, "ts_0x");
+    strcat(string_buff, address_str.c_str());
+    entity_base_info.object_id = string_buff;
+
+    sensor->set_name(entity_base_info.name.c_str());
+    sensor->set_object_id(entity_base_info.object_id.c_str());
+    sensor->set_address(addresses[i]);
+    set_default_parameters_(sensor);
+
+    this->sensors_.push_back(sensor);
+    this->sensors_params_.push_back(std::move(entity_base_info));
+
+    App.register_sensor(sensor);
+    App.register_component(sensor);
+  }
+}
+
+void DallasTemperatureSearcher::set_default_parameters_(dallas_temp::DallasTemperatureSensor *sensor) {
+  sensor->set_device_class("temperature");
+  sensor->set_state_class(sensor::STATE_CLASS_MEASUREMENT);
+  sensor->set_unit_of_measurement("\302\260C");
+  sensor->set_accuracy_decimals(1);
+  sensor->set_force_update(false);
+  sensor->set_update_interval(this->update_interval_ms_);
+  sensor->set_component_source("dallas_temp.sensor");
+  sensor->set_resolution(12);
+}
+
+}  // namespace dallas_temp_searcher
+}  // namespace esphome

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -188,10 +188,10 @@ dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_bas
 }
 
 bool DallasTemperatureSearcher::restore_address_data_(ESPPreferenceObject &obj) {
-  uint64_t temp;
-  if (obj.load(&temp)) {
-    ESP_LOGD(TAG, "Loaded save address from memory 0x%s", format_hex(temp).c_str());
-    saved_addresses_.push_back(temp);
+  uint64_t address;
+  if (obj.load(&address)) {
+    ESP_LOGD(TAG, "Loaded save address from memory 0x%s", format_hex(address).c_str());
+    saved_addresses_.push_back(address);
     return true;
   }
   return false;

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -15,23 +15,116 @@ void DallasTemperatureSearcher::setup() {
 
   const std::vector<uint64_t> &addresses = this->bus_->get_devices();
 
-  this->sensors_params_.reserve(addresses.size());
-  this->sensors_.reserve(addresses.size());
+  if (search_mode_ == SearchMode::ALL) {
+    this->sensors_params_.reserve(addresses.size());
+    this->sensors_.reserve(addresses.size());
 
-  for (const uint64_t &address : addresses) {
-    dallas_temp::DallasTemperatureSensor *sensor = make_sensor_(address);
-
-    this->sensors_.push_back(sensor);
-
-    App.register_sensor(sensor);
-    App.register_component(sensor);
+    for (const uint64_t &address : addresses) {
+      add_sensor_(address);
+    }
+    return;
   }
+
+  // search_mode_ == SearchMode::ADDRESS_MAP
+
+  uint8_t current_work_sensors_num = this->max_sensors_num_;
+
+  this->sensors_params_.reserve(current_work_sensors_num);
+  this->sensors_.reserve(current_work_sensors_num);
+  this->saved_addresses_.reserve(current_work_sensors_num);
+  this->addresses_pref_.reserve(current_work_sensors_num);
+
+  uint32_t hash = fnv1_hash(std::string("_dallas_temp_searcher_test"));
+  this->sensors_count_pref_ = global_preferences->make_preference<uint8_t>(hash, true);
+  this->restore_sensors_count_();
+
+  // need restore addresses
+
+  // Создаем ESPPreferenceObject по максимальному количеству
+  for (uint8_t i = 0; i != current_work_sensors_num; i++) {
+    ESPPreferenceObject address_data_perf = global_preferences->make_preference<uint64_t>(hash + i + 1, true);
+    this->addresses_pref_.push_back(address_data_perf);
+  }
+
+  // Восстанавливаем сколько сохранено адресов
+  for (uint8_t i = 0; i != std::min(this->saved_sensors_num_, this->max_sensors_num_); i++) {
+    if (!restore_address_data_(addresses_pref_[i])) {
+      this->saved_sensors_num_ = i;
+      break;
+    }
+  }
+
+  // Здесь получили вектор сохраненных значений
+
+  uint8_t i = 0;
+  // Первый проход - добавление всех адресов из сохраненных и добавление nullptr отсутствующих
+  for (uint64_t &address : saved_addresses_) {
+    auto it = std::find(addresses.begin(), addresses.end(), address);
+
+    if (it != addresses.end()) {
+      add_sensor_(address);
+    } else {
+      ESP_LOGD(TAG, "Cannot find sensor with address 0x%s", format_hex(address).c_str());
+      sensors_.push_back(nullptr);
+    }
+  }
+
+  // Второй проход - попытка привязать новые адреса по возможности
+  for (const uint64_t &address : addresses) {
+    // Те, что уже есть - мимо
+    auto it = std::find(saved_addresses_.begin(), saved_addresses_.end(), address);
+    if (it != saved_addresses_.end())
+      continue;
+
+    // Если есть еще места - добавляем в конец
+    if (this->saved_addresses_.size() < this->max_sensors_num_) {
+      ESP_LOGD(TAG, "New sensor was added. Address 0x%s", format_hex(address).c_str());
+      saved_addresses_.push_back(address);
+      add_sensor_(address);
+      continue;
+    }
+
+    // Пытаемся найти lost и их заменить
+    auto it2 = std::find(sensors_.begin(), sensors_.end(), nullptr);
+
+    // Нашелся lost - заменяем
+    if (it2 != sensors_.end()) {
+      size_t index = it2 - sensors_.begin();
+      ESP_LOGD(TAG, "Replacing the lost sensor 0x%s with a new one with an address 0x%s",
+               format_hex(saved_addresses_[index]).c_str(), format_hex(address).c_str());
+      *it2 = make_sensor_(address);
+      saved_addresses_[index] = address;
+      App.register_sensor(*it2);
+      App.register_component(*it2);
+
+    } else {
+      // Достигли максимального значения ничего сделать не можем
+      break;
+    }
+  }
+
+  // Синхронизировать найденное
+  this->saved_sensors_num_ = saved_addresses_.size();
+  if (!this->sensors_count_pref_.save(&this->saved_sensors_num_)) {
+    ESP_LOGE(TAG, "Error saving registered sensor count");
+  }
+
+  for (uint8_t i = 0; i < this->saved_sensors_num_; i++) {
+    this->addresses_pref_[i].save(&this->saved_addresses_[i]);
+  }
+  global_preferences->sync();
 }
 
 void DallasTemperatureSearcher::dump_config() {
   ESP_LOGCONFIG(TAG, "Dallas sensor searcher:");
+  uint8_t index = 0;
   for (dallas_temp::DallasTemperatureSensor *sensor : this->sensors_) {
-    ESP_LOGCONFIG(TAG, "  Added %s", sensor->get_name().c_str());
+    if (sensor)
+      ESP_LOGCONFIG(TAG, "  Added %s", sensor->get_name().c_str());
+    else if (search_mode_ == SearchMode::ADDRESS_MAP)
+      ESP_LOGCONFIG(TAG, "  Lost sensor 0x%s", format_hex(this->saved_addresses_[index]).c_str());
+
+    index++;
   }
 }
 
@@ -79,6 +172,24 @@ dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_(co
 
   this->sensors_params_.push_back(std::move(entity_base_info));
   return sensor;
+}
+
+bool DallasTemperatureSearcher::restore_address_data_(ESPPreferenceObject &obj) {
+  uint64_t temp;
+  if (obj.load(&temp)) {
+    ESP_LOGD(TAG, "Loaded save address from memory 0x%s", format_hex(temp).c_str());
+    saved_addresses_.push_back(temp);
+    return true;
+  }
+  return false;
+}
+
+void DallasTemperatureSearcher::restore_sensors_count_() {
+  if (this->sensors_count_pref_.load(&this->saved_sensors_num_)) {
+    ESP_LOGI(TAG, "Successfully restored sensor count from memory - %d", this->saved_sensors_num_);
+  } else {
+    ESP_LOGW(TAG, "No stored sensor count found");
+  }
 }
 
 }  // namespace dallas_temp_searcher

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -46,26 +46,25 @@ void DallasTemperatureSearcher::setup() {
     return;
   }
 
-  // if (this->search_mode_ == SearchMode::ADDRESS_MAP)
+  // Below code for SearchMode::ADDRESS_MAP
 
   this->sensors_params_.reserve(this->max_sensors_num_);
   this->sensors_.reserve(this->max_sensors_num_);
   this->saved_addresses_.reserve(this->max_sensors_num_);
   this->addresses_pref_.reserve(this->max_sensors_num_);
 
+  // Restore sensors count
   uint32_t hash = fnv1_hash(std::string("_dallas_temp_searcher_"));
   this->sensors_count_pref_ = global_preferences->make_preference<uint8_t>(hash, true);
   this->restore_sensors_count_();
 
-  // need restore addresses
-
-  // Создаем ESPPreferenceObject по максимальному количеству
+  // Create ESPPreferenceObjects
   for (uint8_t i = 0; i != this->max_sensors_num_; i++) {
     ESPPreferenceObject address_data_perf = global_preferences->make_preference<uint64_t>(hash + i + 1, true);
     this->addresses_pref_.push_back(address_data_perf);
   }
 
-  // Восстанавливаем сколько сохранено адресов
+  // Restore addresses
   for (uint8_t i = 0; i != std::min(this->saved_sensors_num_, this->max_sensors_num_); i++) {
     if (!restore_address_data_(addresses_pref_[i])) {
       this->saved_sensors_num_ = i;
@@ -73,7 +72,7 @@ void DallasTemperatureSearcher::setup() {
     }
   }
 
-  // Первый проход - добавление всех адресов из сохраненных и добавление nullptr отсутствующих
+  // The first pass is to add all addresses from the saved addresses and add nullptr of the missing ones
   for (uint8_t i = 0; i < this->saved_addresses_.size(); i++) {
     const uint64_t &address = this->saved_addresses_[i];
     auto it = std::find(addresses.begin(), addresses.end(), address);
@@ -87,14 +86,14 @@ void DallasTemperatureSearcher::setup() {
     }
   }
 
-  // Второй проход - попытка привязать новые адреса по возможности
+  // The second pass is an attempt to bind new addresses if possible
   for (const uint64_t &address : addresses) {
-    // Те, что уже есть - мимо
+    // The ones that are already there are gone
     auto it = std::find(this->saved_addresses_.begin(), this->saved_addresses_.end(), address);
     if (it != this->saved_addresses_.end())
       continue;
 
-    // Если есть еще места - добавляем в конец
+    // If there are more places at the end - add to the end
     if (this->saved_addresses_.size() < this->max_sensors_num_) {
       ESP_LOGW(TAG, "New sensor was added. Address 0x%s", format_hex(address).c_str());
       this->saved_addresses_.push_back(address);
@@ -103,19 +102,18 @@ void DallasTemperatureSearcher::setup() {
       continue;
     }
 
-    // Пытаемся найти lost и их заменить
-    auto it2 = std::find(sensors_.begin(), sensors_.end(), nullptr);
+    // Trying to find lost and replace them
+    auto it_lost = std::find(sensors_.begin(), sensors_.end(), nullptr);
 
-    // Нашелся lost - заменяем
-    if (it2 != this->sensors_.end()) {
-      size_t index = it2 - sensors_.begin();
+    if (it_lost != this->sensors_.end()) {
+      size_t index = it_lost - sensors_.begin();
       ESP_LOGW(TAG, "Replacing the lost sensor 0x%s with a new one with an address 0x%s",
                format_hex(this->saved_addresses_[index]).c_str(), format_hex(address).c_str());
-      *it2 = make_sensor_with_number_(address, index + 1);
+      *it_lost = make_sensor_with_number_(address, index + 1);
       this->saved_addresses_[index] = address;
 
     } else {
-      // Достигли максимального значения ничего сделать не можем
+      // Reached the maximum number of sensor and can't do nothing
       break;
     }
   }
@@ -127,7 +125,7 @@ void DallasTemperatureSearcher::setup() {
     }
   }
 
-  // Синхронизировать найденное
+  // Sync memory
   this->saved_sensors_num_ = this->saved_addresses_.size();
   if (!this->sensors_count_pref_.save(&this->saved_sensors_num_)) {
     ESP_LOGE(TAG, "Error saving registered sensor count");

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -9,18 +9,39 @@ namespace dallas_temp_searcher {
 
 static const char *const TAG = "dallas.temp.searcher";
 
+template<typename... Args> EntityBaseInfo make_sensor_info_(const char *format, Args... args) {
+  const size_t string_buffer_size = 64;
+  char string_buff[string_buffer_size];
+
+  EntityBaseInfo entity_base_info;
+
+  strcpy(string_buff, "Temp Sensor ");
+  snprintf(string_buff + strlen(string_buff), string_buffer_size, format, args...);
+  entity_base_info.name = string_buff;
+
+  strcpy(string_buff, "dallas_searcher_temp_sensor_");
+  snprintf(string_buff + strlen(string_buff), string_buffer_size, format, args...);
+  entity_base_info.object_id = string_buff;
+
+  return entity_base_info;
+}
+
 void DallasTemperatureSearcher::setup() {
   if (this->bus_ == nullptr)
     return;
 
   const std::vector<uint64_t> &addresses = this->bus_->get_devices();
 
-  if (search_mode_ == SearchMode::ALL) {
+  if (this->search_mode_ == SearchMode::ALL) {
     this->sensors_params_.reserve(addresses.size());
     this->sensors_.reserve(addresses.size());
 
     for (const uint64_t &address : addresses) {
-      add_sensor_(address);
+      auto *sensor = make_sensor_with_address_(address);
+      this->sensors_.push_back(sensor);
+
+      App.register_sensor(sensor);
+      App.register_component(sensor);
     }
     return;
   }
@@ -62,11 +83,13 @@ void DallasTemperatureSearcher::setup() {
     auto it = std::find(addresses.begin(), addresses.end(), address);
 
     if (it != addresses.end()) {
-      add_sensor_(address);
+      auto *sensor = make_sensor_with_number_(address, i + 1);
+      this->sensors_.push_back(sensor);
     } else {
       ESP_LOGD(TAG, "Cannot find sensor with address 0x%s", format_hex(address).c_str());
       sensors_.push_back(nullptr);
     }
+    i++;
   }
 
   // Второй проход - попытка привязать новые адреса по возможности
@@ -80,7 +103,8 @@ void DallasTemperatureSearcher::setup() {
     if (this->saved_addresses_.size() < this->max_sensors_num_) {
       ESP_LOGD(TAG, "New sensor was added. Address 0x%s", format_hex(address).c_str());
       saved_addresses_.push_back(address);
-      add_sensor_(address);
+      auto *sensor = make_sensor_with_number_(address, saved_addresses_.size());
+      this->sensors_.push_back(sensor);
       continue;
     }
 
@@ -92,14 +116,19 @@ void DallasTemperatureSearcher::setup() {
       size_t index = it2 - sensors_.begin();
       ESP_LOGD(TAG, "Replacing the lost sensor 0x%s with a new one with an address 0x%s",
                format_hex(saved_addresses_[index]).c_str(), format_hex(address).c_str());
-      *it2 = make_sensor_(address);
+      *it2 = make_sensor_with_number_(address, index + 1);
       saved_addresses_[index] = address;
-      App.register_sensor(*it2);
-      App.register_component(*it2);
 
     } else {
       // Достигли максимального значения ничего сделать не можем
       break;
+    }
+  }
+
+  for (auto *sensor : sensors_) {
+    if (sensor) {
+      App.register_sensor(sensor);
+      App.register_component(sensor);
     }
   }
 
@@ -139,38 +168,30 @@ void DallasTemperatureSearcher::set_default_parameters_(dallas_temp::DallasTempe
   sensor->set_resolution(12);
 }
 
-void DallasTemperatureSearcher::add_sensor_(const uint64_t &address) {
-  dallas_temp::DallasTemperatureSensor *sensor = make_sensor_(address);
-  this->sensors_.push_back(sensor);
-
-  App.register_sensor(sensor);
-  App.register_component(sensor);
+dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_address_(const uint64_t &address) {
+  EntityBaseInfo info = make_sensor_info_("0x%s", format_hex(address).c_str());
+  ESP_LOGI(TAG, "info %s - %s", info.name.c_str(), info.object_id.c_str());
+  return make_sensor_(address, std::move(info));
 }
 
-dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_(const uint64_t &address) {
-  const size_t string_buffer_size = 32;
-  char string_buff[string_buffer_size];
+dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_number_(const uint64_t &address,
+                                                                                          uint32_t number) {
+  ESP_LOGI(TAG, "info number %d", number);
+  EntityBaseInfo info = make_sensor_info_("number_%d", number);
+  ESP_LOGI(TAG, "info %s - %s", info.name.c_str(), info.object_id.c_str());
+  return make_sensor_(address, std::move(info));
+}
 
+dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_(const uint64_t &address,
+                                                                              EntityBaseInfo &&info) {
   auto *sensor = new dallas_temp::DallasTemperatureSensor();
-  EntityBaseInfo entity_base_info;
   sensor->set_one_wire_bus(bus_);
-
-  std::string address_str = format_hex(address);
-
-  strcpy(string_buff, "Temp Sensor 0x");
-  strlcat(string_buff, address_str.c_str(), string_buffer_size);
-  entity_base_info.name = string_buff;
-
-  strcpy(string_buff, "ts_0x");
-  strlcat(string_buff, address_str.c_str(), string_buffer_size);
-  entity_base_info.object_id = string_buff;
-
-  sensor->set_name(entity_base_info.name.c_str());
-  sensor->set_object_id(entity_base_info.object_id.c_str());
+  sensor->set_name(info.name.c_str());
+  sensor->set_object_id(info.object_id.c_str());
   sensor->set_address(address);
   set_default_parameters_(sensor);
 
-  this->sensors_params_.push_back(std::move(entity_base_info));
+  this->sensors_params_.push_back(std::move(info));
   return sensor;
 }
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -46,6 +46,14 @@ void DallasTemperatureSearcher::set_default_parameters_(dallas_temp::DallasTempe
   sensor->set_resolution(12);
 }
 
+void DallasTemperatureSearcher::add_sensor_(const uint64_t &address) {
+  dallas_temp::DallasTemperatureSensor *sensor = make_sensor_(address);
+  this->sensors_.push_back(sensor);
+
+  App.register_sensor(sensor);
+  App.register_component(sensor);
+}
+
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_(const uint64_t &address) {
   const size_t string_buffer_size = 32;
   char string_buff[string_buffer_size];

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -173,7 +173,7 @@ void DallasTemperatureSearcher::set_default_parameters_(dallas_temp::DallasTempe
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_address_(const uint64_t &address) {
   EntityBaseInfo info = make_sensor_info("0x%s", format_hex(address).c_str());
   ESP_LOGI(TAG, "info %s - %s", info.name.c_str(), info.object_id.c_str());
-  return make_sensor_(address, std::move(info));
+  return make_sensor_base_(address, std::move(info));
 }
 
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_number_(const uint64_t &address,
@@ -181,11 +181,11 @@ dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_wit
   ESP_LOGI(TAG, "info number %d", number);
   EntityBaseInfo info = make_sensor_info("number_%d", number);
   ESP_LOGI(TAG, "info %s - %s", info.name.c_str(), info.object_id.c_str());
-  return make_sensor_(address, std::move(info));
+  return make_sensor_base_(address, std::move(info));
 }
 
-dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_(const uint64_t &address,
-                                                                              EntityBaseInfo &&info) {
+dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_base_(const uint64_t &address,
+                                                                                   EntityBaseInfo &&info) {
   auto *sensor = new dallas_temp::DallasTemperatureSensor();
   sensor->set_one_wire_bus(bus_);
   sensor->set_name(info.name.c_str());

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -53,7 +53,7 @@ void DallasTemperatureSearcher::setup() {
   this->saved_addresses_.reserve(this->max_sensors_num_);
   this->addresses_pref_.reserve(this->max_sensors_num_);
 
-  uint32_t hash = fnv1_hash(std::string("_dallas_temp_searcher_test"));
+  uint32_t hash = fnv1_hash(std::string("_dallas_temp_searcher_"));
   this->sensors_count_pref_ = global_preferences->make_preference<uint8_t>(hash, true);
   this->restore_sensors_count_();
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -46,14 +46,12 @@ void DallasTemperatureSearcher::setup() {
     return;
   }
 
-  // search_mode_ == SearchMode::ADDRESS_MAP
+  // if (this->search_mode_ == SearchMode::ADDRESS_MAP)
 
-  uint8_t current_work_sensors_num = this->max_sensors_num_;
-
-  this->sensors_params_.reserve(current_work_sensors_num);
-  this->sensors_.reserve(current_work_sensors_num);
-  this->saved_addresses_.reserve(current_work_sensors_num);
-  this->addresses_pref_.reserve(current_work_sensors_num);
+  this->sensors_params_.reserve(this->max_sensors_num_);
+  this->sensors_.reserve(this->max_sensors_num_);
+  this->saved_addresses_.reserve(this->max_sensors_num_);
+  this->addresses_pref_.reserve(this->max_sensors_num_);
 
   uint32_t hash = fnv1_hash(std::string("_dallas_temp_searcher_test"));
   this->sensors_count_pref_ = global_preferences->make_preference<uint8_t>(hash, true);
@@ -62,7 +60,7 @@ void DallasTemperatureSearcher::setup() {
   // need restore addresses
 
   // Создаем ESPPreferenceObject по максимальному количеству
-  for (uint8_t i = 0; i != current_work_sensors_num; i++) {
+  for (uint8_t i = 0; i != this->max_sensors_num_; i++) {
     ESPPreferenceObject address_data_perf = global_preferences->make_preference<uint64_t>(hash + i + 1, true);
     this->addresses_pref_.push_back(address_data_perf);
   }
@@ -75,35 +73,32 @@ void DallasTemperatureSearcher::setup() {
     }
   }
 
-  // Здесь получили вектор сохраненных значений
-
-  uint8_t i = 0;
   // Первый проход - добавление всех адресов из сохраненных и добавление nullptr отсутствующих
-  for (uint64_t &address : saved_addresses_) {
+  for (uint8_t i = 0; i < this->saved_addresses_.size(); i++) {
+    const uint64_t &address = this->saved_addresses_[i];
     auto it = std::find(addresses.begin(), addresses.end(), address);
 
     if (it != addresses.end()) {
       auto *sensor = make_sensor_with_number_(address, i + 1);
       this->sensors_.push_back(sensor);
     } else {
-      ESP_LOGD(TAG, "Cannot find sensor with address 0x%s", format_hex(address).c_str());
-      sensors_.push_back(nullptr);
+      ESP_LOGW(TAG, "Cannot find sensor with address 0x%s", format_hex(address).c_str());
+      this->sensors_.push_back(nullptr);
     }
-    i++;
   }
 
   // Второй проход - попытка привязать новые адреса по возможности
   for (const uint64_t &address : addresses) {
     // Те, что уже есть - мимо
-    auto it = std::find(saved_addresses_.begin(), saved_addresses_.end(), address);
-    if (it != saved_addresses_.end())
+    auto it = std::find(this->saved_addresses_.begin(), this->saved_addresses_.end(), address);
+    if (it != this->saved_addresses_.end())
       continue;
 
     // Если есть еще места - добавляем в конец
     if (this->saved_addresses_.size() < this->max_sensors_num_) {
-      ESP_LOGD(TAG, "New sensor was added. Address 0x%s", format_hex(address).c_str());
-      saved_addresses_.push_back(address);
-      auto *sensor = make_sensor_with_number_(address, saved_addresses_.size());
+      ESP_LOGW(TAG, "New sensor was added. Address 0x%s", format_hex(address).c_str());
+      this->saved_addresses_.push_back(address);
+      auto *sensor = make_sensor_with_number_(address, this->saved_addresses_.size());
       this->sensors_.push_back(sensor);
       continue;
     }
@@ -112,12 +107,12 @@ void DallasTemperatureSearcher::setup() {
     auto it2 = std::find(sensors_.begin(), sensors_.end(), nullptr);
 
     // Нашелся lost - заменяем
-    if (it2 != sensors_.end()) {
+    if (it2 != this->sensors_.end()) {
       size_t index = it2 - sensors_.begin();
-      ESP_LOGD(TAG, "Replacing the lost sensor 0x%s with a new one with an address 0x%s",
-               format_hex(saved_addresses_[index]).c_str(), format_hex(address).c_str());
+      ESP_LOGW(TAG, "Replacing the lost sensor 0x%s with a new one with an address 0x%s",
+               format_hex(this->saved_addresses_[index]).c_str(), format_hex(address).c_str());
       *it2 = make_sensor_with_number_(address, index + 1);
-      saved_addresses_[index] = address;
+      this->saved_addresses_[index] = address;
 
     } else {
       // Достигли максимального значения ничего сделать не можем
@@ -125,7 +120,7 @@ void DallasTemperatureSearcher::setup() {
     }
   }
 
-  for (auto *sensor : sensors_) {
+  for (auto *sensor : this->sensors_) {
     if (sensor) {
       App.register_sensor(sensor);
       App.register_component(sensor);
@@ -133,7 +128,7 @@ void DallasTemperatureSearcher::setup() {
   }
 
   // Синхронизировать найденное
-  this->saved_sensors_num_ = saved_addresses_.size();
+  this->saved_sensors_num_ = this->saved_addresses_.size();
   if (!this->sensors_count_pref_.save(&this->saved_sensors_num_)) {
     ESP_LOGE(TAG, "Error saving registered sensor count");
   }
@@ -172,15 +167,12 @@ void DallasTemperatureSearcher::set_default_parameters_(dallas_temp::DallasTempe
 
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_address_(const uint64_t &address) {
   EntityBaseInfo info = make_sensor_info("0x%s", format_hex(address).c_str());
-  ESP_LOGI(TAG, "info %s - %s", info.name.c_str(), info.object_id.c_str());
   return make_sensor_base_(address, std::move(info));
 }
 
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_number_(const uint64_t &address,
                                                                                           uint32_t number) {
-  ESP_LOGI(TAG, "info number %d", number);
   EntityBaseInfo info = make_sensor_info("number_%d", number);
-  ESP_LOGI(TAG, "info %s - %s", info.name.c_str(), info.object_id.c_str());
   return make_sensor_base_(address, std::move(info));
 }
 
@@ -209,7 +201,7 @@ bool DallasTemperatureSearcher::restore_address_data_(ESPPreferenceObject &obj) 
 
 void DallasTemperatureSearcher::restore_sensors_count_() {
   if (this->sensors_count_pref_.load(&this->saved_sensors_num_)) {
-    ESP_LOGI(TAG, "Successfully restored sensor count from memory - %d", this->saved_sensors_num_);
+    ESP_LOGD(TAG, "Successfully restored sensor count from memory - %d", this->saved_sensors_num_);
   } else {
     ESP_LOGW(TAG, "No stored sensor count found");
   }

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -9,7 +9,7 @@ namespace dallas_temp_searcher {
 
 static const char *const TAG = "dallas.temp.searcher";
 
-template<typename... Args> EntityBaseInfo make_sensor_info_(const char *format, Args... args) {
+template<typename... Args> EntityBaseInfo make_sensor_info(const char *format, Args... args) {
   const size_t string_buffer_size = 64;
   char string_buff[string_buffer_size];
 
@@ -148,10 +148,12 @@ void DallasTemperatureSearcher::dump_config() {
   ESP_LOGCONFIG(TAG, "Dallas sensor searcher:");
   uint8_t index = 0;
   for (dallas_temp::DallasTemperatureSensor *sensor : this->sensors_) {
-    if (sensor)
+    if (sensor) {
       ESP_LOGCONFIG(TAG, "  Added %s", sensor->get_name().c_str());
-    else if (search_mode_ == SearchMode::ADDRESS_MAP)
+
+    } else if (search_mode_ == SearchMode::ADDRESS_MAP) {
       ESP_LOGCONFIG(TAG, "  Lost sensor 0x%s", format_hex(this->saved_addresses_[index]).c_str());
+    }
 
     index++;
   }
@@ -169,7 +171,7 @@ void DallasTemperatureSearcher::set_default_parameters_(dallas_temp::DallasTempe
 }
 
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_address_(const uint64_t &address) {
-  EntityBaseInfo info = make_sensor_info_("0x%s", format_hex(address).c_str());
+  EntityBaseInfo info = make_sensor_info("0x%s", format_hex(address).c_str());
   ESP_LOGI(TAG, "info %s - %s", info.name.c_str(), info.object_id.c_str());
   return make_sensor_(address, std::move(info));
 }
@@ -177,7 +179,7 @@ dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_wit
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_number_(const uint64_t &address,
                                                                                           uint32_t number) {
   ESP_LOGI(TAG, "info number %d", number);
-  EntityBaseInfo info = make_sensor_info_("number_%d", number);
+  EntityBaseInfo info = make_sensor_info("number_%d", number);
   ESP_LOGI(TAG, "info %s - %s", info.name.c_str(), info.object_id.c_str());
   return make_sensor_(address, std::move(info));
 }

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -7,6 +7,7 @@
 namespace esphome {
 namespace dallas_temp_searcher {
 
+// Class for dynamic creation DallasTemperatureSensor for sensors connected to onewire bus
 class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevice {
  public:
   void setup() override;
@@ -19,10 +20,12 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
 
   void dump_config() override;
 
-  uint16_t sensors_size() { return sensors_.size(); }
+  uint16_t sensors_size() { return this->sensors_.size(); }
 
   dallas_temp::DallasTemperatureSensor *sensor(uint16_t index) {
-    return index < sensors_.size() ? sensors_[index] : nullptr;
+    if (index >= this->sensors_.size())
+      return nullptr;
+    return this->sensors_[index];
   }
 
  protected:

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -17,6 +17,8 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
   // Update interval for all sensors
   void set_update_interval(uint32_t update_interval_ms) { this->update_interval_ms_ = update_interval_ms; }
 
+  void dump_config() override;
+
  protected:
   void set_default_parameters_(dallas_temp::DallasTemperatureSensor *sensor);
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -19,6 +19,12 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
 
   void dump_config() override;
 
+  uint16_t sensors_size() { return sensors_.size(); }
+
+  dallas_temp::DallasTemperatureSensor *sensor(uint16_t index) {
+    return index < sensors_.size() ? sensors_[index] : nullptr;
+  }
+
  protected:
   void set_default_parameters_(dallas_temp::DallasTemperatureSensor *sensor);
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esphome/core/component.h"
+#include "esphome/components/dallas_temp/dallas_temp.h"
+#include <vector>
+
+namespace esphome {
+namespace dallas_temp_searcher {
+
+class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevice {
+ public:
+  void setup() override;
+
+  // setup should be called before setup dallas temp sensors
+  float get_setup_priority() const override { return setup_priority::DATA + 1; }
+
+  // Update interval for all sensors
+  void set_update_interval(uint32_t update_interval_ms) { this->update_interval_ms_ = update_interval_ms; }
+
+ protected:
+  void set_default_parameters_(dallas_temp::DallasTemperatureSensor *sensor);
+
+  std::vector<dallas_temp::DallasTemperatureSensor *> sensors_;
+  std::vector<EntityBaseInfo> sensors_params_;
+  uint32_t update_interval_ms_ = 60000;
+};
+
+}  // namespace dallas_temp_searcher
+}  // namespace esphome

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -31,6 +31,8 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
  protected:
   void set_default_parameters_(dallas_temp::DallasTemperatureSensor *sensor);
 
+  dallas_temp::DallasTemperatureSensor *make_sensor_(const uint64_t &address);
+
   std::vector<dallas_temp::DallasTemperatureSensor *> sensors_;
   std::vector<EntityBaseInfo> sensors_params_;
   uint32_t update_interval_ms_ = 60000;

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -25,10 +25,10 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
 
   uint16_t sensors_size() { return this->sensors_.size(); }
 
-  dallas_temp::DallasTemperatureSensor *sensor(uint16_t index) {
-    if (index >= this->sensors_.size())
+  dallas_temp::DallasTemperatureSensor *sensor(uint16_t number) {
+    if (number > this->sensors_.size() || number == 0)
       return nullptr;
-    return this->sensors_[index];
+    return this->sensors_[number - 1];
   }
 
   void set_search_mode(SearchMode mode) { this->search_mode_ = mode; }
@@ -40,8 +40,9 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
   void restore_sensors_count_();
   bool restore_address_data_(ESPPreferenceObject &obj);
 
-  dallas_temp::DallasTemperatureSensor *make_sensor_(const uint64_t &address);
-  void add_sensor_(const uint64_t &address);
+  dallas_temp::DallasTemperatureSensor *make_sensor_(const uint64_t &address, EntityBaseInfo &&info);
+  dallas_temp::DallasTemperatureSensor *make_sensor_with_address_(const uint64_t &address);
+  dallas_temp::DallasTemperatureSensor *make_sensor_with_number_(const uint64_t &address, uint32_t number);
 
   std::vector<dallas_temp::DallasTemperatureSensor *> sensors_;
   std::vector<EntityBaseInfo> sensors_params_;

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -32,6 +32,7 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
   void set_default_parameters_(dallas_temp::DallasTemperatureSensor *sensor);
 
   dallas_temp::DallasTemperatureSensor *make_sensor_(const uint64_t &address);
+  void add_sensor_(const uint64_t &address);
 
   std::vector<dallas_temp::DallasTemperatureSensor *> sensors_;
   std::vector<EntityBaseInfo> sensors_params_;

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -40,7 +40,7 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
   void restore_sensors_count_();
   bool restore_address_data_(ESPPreferenceObject &obj);
 
-  dallas_temp::DallasTemperatureSensor *make_sensor_(const uint64_t &address, EntityBaseInfo &&info);
+  dallas_temp::DallasTemperatureSensor *make_sensor_base_(const uint64_t &address, EntityBaseInfo &&info);
   dallas_temp::DallasTemperatureSensor *make_sensor_with_address_(const uint64_t &address);
   dallas_temp::DallasTemperatureSensor *make_sensor_with_number_(const uint64_t &address, uint32_t number);
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -1,11 +1,14 @@
 #pragma once
 
 #include "esphome/core/component.h"
+#include "esphome/core/preferences.h"
 #include "esphome/components/dallas_temp/dallas_temp.h"
 #include <vector>
 
 namespace esphome {
 namespace dallas_temp_searcher {
+
+enum class SearchMode : uint8_t { ALL = 0, ADDRESS_MAP = 1 };
 
 // Class for dynamic creation DallasTemperatureSensor for sensors connected to onewire bus
 class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevice {
@@ -28,8 +31,14 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
     return this->sensors_[index];
   }
 
+  void set_search_mode(SearchMode mode) { this->search_mode_ = mode; }
+
+  void set_max_sensors_num(size_t max_num) { this->max_sensors_num_ = max_num; }
+
  protected:
   void set_default_parameters_(dallas_temp::DallasTemperatureSensor *sensor);
+  void restore_sensors_count_();
+  bool restore_address_data_(ESPPreferenceObject &obj);
 
   dallas_temp::DallasTemperatureSensor *make_sensor_(const uint64_t &address);
   void add_sensor_(const uint64_t &address);
@@ -37,6 +46,15 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
   std::vector<dallas_temp::DallasTemperatureSensor *> sensors_;
   std::vector<EntityBaseInfo> sensors_params_;
   uint32_t update_interval_ms_ = 60000;
+  uint8_t max_sensors_num_;
+
+  uint8_t saved_sensors_num_ = 0;
+
+  std::vector<uint64_t> saved_addresses_;
+
+  SearchMode search_mode_ = SearchMode::ALL;
+  ESPPreferenceObject sensors_count_pref_;
+  std::vector<ESPPreferenceObject> addresses_pref_;
 };
 
 }  // namespace dallas_temp_searcher

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -32,22 +32,24 @@ void Application::setup() {
     return a->get_actual_setup_priority() > b->get_actual_setup_priority();
   });
 
-  for (uint32_t i = 0; i < this->components_.size(); i++) {
-    Component *component = this->components_[i];
+  size_t last_components_size = this->components_.size();
 
-    size_t last_components_size = this->components_.size();
+  for (uint32_t i = 0; i < this->components_.size(); i++) {
+    // if previous component dynamically added other components in its call setup or loop, resorting of components is
+    // needed
+    if (this->components_.size() != last_components_size) {
+      std::stable_sort(this->components_.begin() + i, this->components_.end(), [](Component *a, Component *b) {
+        return a->get_actual_setup_priority() > b->get_actual_setup_priority();
+      });
+      last_components_size = this->components_.size();
+    }
+
+    Component *component = this->components_[i];
     // Update loop_component_start_time_ before calling each component during setup
     this->loop_component_start_time_ = millis();
     component->call();
     this->scheduler.process_to_add();
     this->feed_wdt();
-
-    // if current component dynamically added other components in its call setup, sorting of next components is needed
-    if (this->components_.size() != last_components_size) {
-      std::stable_sort(this->components_.begin() + i + 1, this->components_.end(), [](Component *a, Component *b) {
-        return a->get_actual_setup_priority() > b->get_actual_setup_priority();
-      });
-    }
 
     if (component->can_proceed())
       continue;

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -35,11 +35,20 @@ void Application::setup() {
   for (uint32_t i = 0; i < this->components_.size(); i++) {
     Component *component = this->components_[i];
 
+    size_t last_components_size = this->components_.size();
     // Update loop_component_start_time_ before calling each component during setup
     this->loop_component_start_time_ = millis();
     component->call();
     this->scheduler.process_to_add();
     this->feed_wdt();
+
+    // if current component dynamically added other components in its call setup, sorting of next components is needed
+    if (this->components_.size() != last_components_size) {
+      std::stable_sort(this->components_.begin() + i + 1, this->components_.end(), [](Component *a, Component *b) {
+        return a->get_actual_setup_priority() > b->get_actual_setup_priority();
+      });
+    }
+
     if (component->can_proceed())
       continue;
 

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -85,4 +85,11 @@ class EntityBase_UnitOfMeasurement {  // NOLINT(readability-identifier-naming)
   const char *unit_of_measurement_{nullptr};  ///< Unit of measurement override
 };
 
+// Entity information allocated dynamically
+struct EntityBaseInfo {
+  std::string name;
+  std::string object_id;
+  std::string icon;
+};
+
 }  // namespace esphome

--- a/tests/components/dallas_temp_searcher/common.yaml
+++ b/tests/components/dallas_temp_searcher/common.yaml
@@ -1,0 +1,9 @@
+one_wire:
+  id: one_wire1_id
+  platform: gpio
+  pin: 4
+
+dallas_temp_searcher:
+  id: dallas_searcher_id
+  one_wire_id: one_wire1_id
+  update_interval: 20s


### PR DESCRIPTION
# What does this implement/fix?

Два режима работы - поиск всех устройств на линии и добавление их как сенсоры (mode: all),
Режим работы mode: address_map.
1. Задается число датчиков с помощью max_sensors_num
2. Датчики по очереди подключаются к линии (подключил, перезагрузил)
3. После подключения всех датчиков они имеют имя Temp sensor 1, Temp sensor 2...
4. В случае выхода из строя одного из датчиков, замена датчика приведет к тому, что он встанет на место неисправного. Останутся все автоматизации в HA и обращение через лямбды id(dallas_searcher_id).sensor(1);

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml

one_wire:
  id: one_wire1_id
  platform: gpio
  pin: GPIO15

# Example config.yaml

 dallas_temp_searcher:
   id: dallas_searcher_id
   update_interval: 20s
   one_wire_id: one_wire1_id

OR

dallas_temp_searcher:
  id: dallas_searcher_id
  update_interval: 2s
  one_wire_id: one_wire1_id
  max_sensors_num: 0
  mode: address_map

interval:
- interval: 20s
  then:
  - lambda: |-
      auto sensor = id(dallas_searcher_id).sensor(1);
      if (sensor) {
        ESP_LOGD("DTS TEST", "Temp 1 %f", sensor->state);
      }
      else {
        ESP_LOGD("DTS TEST","Error");
      }
```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
