### PR TITLE
[JXD-204] Добавил back action для graphical menu, опция для возможноcти отключить вход в меню при действии джойстиком вправо

### DIFF
--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -269,7 +269,6 @@ DISPLAY_MENU_BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
         cv.GenerateID(CONF_ROOT_ITEM_ID): cv.declare_id(MenuItemMenu),
         cv.Optional(CONF_MODE, default=CONF_ROTARY): cv.enum(MENU_MODES),
-        cv.Optional(CONF_MODE, default=CONF_ROTARY): cv.enum(MENU_MODES),
         cv.Optional(CONF_RIGHT_FOR_MENU_ENTER, default=True): cv.boolean,
         cv.Optional(CONF_ON_ENTER): automation.validate_automation(
             {

--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -29,6 +29,7 @@ display_menu_base_ns = cg.esphome_ns.namespace("display_menu_base")
 
 CONF_ROTARY = "rotary"
 CONF_JOYSTICK = "joystick"
+CONF_RIGHT_FOR_MENU_ENTER = "right_for_menu_enter"
 CONF_LABEL = "label"
 CONF_MENU = "menu"
 CONF_BACK = "back"
@@ -62,6 +63,7 @@ RightAction = display_menu_base_ns.class_("RightAction", automation.Action)
 EnterAction = display_menu_base_ns.class_("EnterAction", automation.Action)
 ShowAction = display_menu_base_ns.class_("ShowAction", automation.Action)
 HideAction = display_menu_base_ns.class_("HideAction", automation.Action)
+BackAction = display_menu_base_ns.class_("BackAction", automation.Action)
 ShowMainAction = display_menu_base_ns.class_("ShowMainAction", automation.Action)
 
 IsActiveCondition = display_menu_base_ns.class_(
@@ -267,6 +269,8 @@ DISPLAY_MENU_BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_ACTIVE, default=True): cv.boolean,
         cv.GenerateID(CONF_ROOT_ITEM_ID): cv.declare_id(MenuItemMenu),
         cv.Optional(CONF_MODE, default=CONF_ROTARY): cv.enum(MENU_MODES),
+        cv.Optional(CONF_MODE, default=CONF_ROTARY): cv.enum(MENU_MODES),
+        cv.Optional(CONF_RIGHT_FOR_MENU_ENTER, default=True): cv.boolean,
         cv.Optional(CONF_ON_ENTER): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -332,6 +336,12 @@ async def menu_show_to_code(config, action_id, template_arg, args):
 
 @automation.register_action("display_menu.hide", HideAction, MENU_ACTION_SCHEMA)
 async def menu_hide_to_code(config, action_id, template_arg, args):
+    paren = await cg.get_variable(config[CONF_ID])
+    return cg.new_Pvariable(action_id, template_arg, paren)
+
+
+@automation.register_action("display_menu.back", BackAction, MENU_ACTION_SCHEMA)
+async def menu_back_to_code(config, action_id, template_arg, args):
     paren = await cg.get_variable(config[CONF_ID])
     return cg.new_Pvariable(action_id, template_arg, paren)
 
@@ -418,6 +428,7 @@ async def display_menu_to_code(menu, config):
     root_item = cg.new_Pvariable(config[CONF_ROOT_ITEM_ID])
     cg.add(menu.set_root_item(root_item))
     cg.add(menu.set_mode(config[CONF_MODE]))
+    cg.add(menu.set_right_for_menu_enter_opt(config[CONF_RIGHT_FOR_MENU_ENTER]))
     for c in config[CONF_ITEMS]:
         await menu_item_to_code(menu, c, root_item)
     for conf in config.get(CONF_ON_ENTER, []):

--- a/esphome/components/display_menu_base/automation.h
+++ b/esphome/components/display_menu_base/automation.h
@@ -76,6 +76,16 @@ template<typename... Ts> class HideAction : public Action<Ts...> {
   DisplayMenuComponent *menu_;
 };
 
+template<typename... Ts> class BackAction : public Action<Ts...> {
+ public:
+  explicit BackAction(DisplayMenuComponent *menu) : menu_(menu) {}
+
+  void play(Ts... x) override { this->menu_->back(); }
+
+ protected:
+  DisplayMenuComponent *menu_;
+};
+
 template<typename... Ts> class ShowMainAction : public Action<Ts...> {
  public:
   explicit ShowMainAction(DisplayMenuComponent *menu) : menu_(menu) {}

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -102,9 +102,36 @@ void DisplayMenuComponent::right() {
         }
         break;
       case MENU_ITEM_MENU:
-        changed = this->enter_menu_();
+        if (right_for_menu_enter_opt_)
+          changed = this->enter_menu_();
         break;
       default:
+        break;
+    }
+
+    if (changed)
+      this->draw_and_update();
+  }
+}
+
+void DisplayMenuComponent::back() {
+  if (this->check_healthy_and_active_()) {
+    bool changed = false;
+
+    switch (this->get_selected_item_()->get_type()) {
+      case MENU_ITEM_SELECT:
+      case MENU_ITEM_SWITCH:
+      case MENU_ITEM_NUMBER:
+      case MENU_ITEM_CUSTOM:
+        if (this->editing_) {
+          this->finish_editing_();
+          changed = true;
+        } else {
+          changed = this->leave_menu_();
+        }
+        break;
+      default:
+        changed = this->leave_menu_();
         break;
     }
 

--- a/esphome/components/display_menu_base/display_menu_base.h
+++ b/esphome/components/display_menu_base/display_menu_base.h
@@ -24,6 +24,7 @@ class DisplayMenuComponent : public Component {
   void set_root_item(MenuItemMenu *item) { this->displayed_item_ = this->root_item_ = item; }
   void set_active(bool active) { this->active_ = active; }
   void set_mode(MenuMode mode) { this->mode_ = mode; }
+  void set_right_for_menu_enter_opt(bool opt) { this->right_for_menu_enter_opt_ = opt; }
   void set_rows(uint8_t rows) { this->rows_ = rows; }
 
   float get_setup_priority() const override { return setup_priority::PROCESSOR; }
@@ -33,6 +34,7 @@ class DisplayMenuComponent : public Component {
   void left();
   void right();
   void enter();
+  void back();
 
   void show_main();
   void show();
@@ -68,6 +70,7 @@ class DisplayMenuComponent : public Component {
   uint8_t rows_;
   bool active_;
   MenuMode mode_;
+  bool right_for_menu_enter_opt_{true};
   MenuItemMenu *root_item_{nullptr};
 
   MenuItemMenu *displayed_item_{nullptr};

--- a/esphome/components/display_menu_base/display_menu_base.h
+++ b/esphome/components/display_menu_base/display_menu_base.h
@@ -24,6 +24,10 @@ class DisplayMenuComponent : public Component {
   void set_root_item(MenuItemMenu *item) { this->displayed_item_ = this->root_item_ = item; }
   void set_active(bool active) { this->active_ = active; }
   void set_mode(MenuMode mode) { this->mode_ = mode; }
+
+  /** Set whether the "right" input should be used to enter menu options.
+   * @param opt True to enable "right" input for menu entry, false to disable.
+   */
   void set_right_for_menu_enter_opt(bool opt) { this->right_for_menu_enter_opt_ = opt; }
   void set_rows(uint8_t rows) { this->rows_ = rows; }
 


### PR DESCRIPTION
# What does this implement/fix?

Новое действие  
- display_menu.back:
Заканчивает редактирование или возвращает на пункт меню выше

Опция для graphical_display_menu
right_for_menu_enter: false
При false зайти в меню возможно только при нажатии на enter

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
binary_sensor:
 - platform: gpio
    name: "ESC"
    pin:
      pca9554: jxd_display_exp
      number: 13
      mode:
        input: true
      inverted: false
    on_press:
      then:
        - display_menu.back:

graphical_display_menu:
  id: display_menu
  font: font1
  display: display1
  right_for_menu_enter: false

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
