### PR TITLE
[JXD-164] Использование в config компонент wifi и ethernet

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -18,6 +18,7 @@ from esphome.const import (
     CONF_DNS1,
     CONF_DNS2,
     CONF_DOMAIN,
+    CONF_ENABLE_ON_BOOT,
     CONF_GATEWAY,
     CONF_ID,
     CONF_INTERRUPT_PIN,
@@ -39,7 +40,6 @@ from esphome.const import (
 from esphome.core import CORE, TimePeriodMilliseconds, coroutine_with_priority
 import esphome.final_validate as fv
 
-CONFLICTS_WITH = ["wifi"]
 DEPENDENCIES = ["esp32"]
 AUTO_LOAD = ["network"]
 LOGGER = logging.getLogger(__name__)
@@ -162,6 +162,7 @@ BASE_SCHEMA = cv.Schema(
         cv.Optional(CONF_MANUAL_IP): MANUAL_IP_SCHEMA,
         cv.Optional(CONF_DOMAIN, default=".local"): cv.domain_name,
         cv.Optional(CONF_USE_ADDRESS): cv.string_strict,
+        cv.Optional(CONF_ENABLE_ON_BOOT, default=True): cv.boolean,
         cv.Optional("enable_mdns"): cv.invalid(
             "This option has been removed. Please use the [disabled] option under the "
             "new mdns component instead."
@@ -317,6 +318,7 @@ async def to_code(config):
 
     cg.add(var.set_type(ETHERNET_TYPES[config[CONF_TYPE]]))
     cg.add(var.set_use_address(config[CONF_USE_ADDRESS]))
+    cg.add(var.set_enable_on_boot(config[CONF_ENABLE_ON_BOOT]))
 
     if CONF_MANUAL_IP in config:
         cg.add(var.set_manual_ip(manual_ip(config[CONF_MANUAL_IP])))

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -79,7 +79,12 @@ void EthernetComponent::setup() {
   err = esp_netif_init();
   ESPHL_ERROR_CHECK(err, "ETH netif init error");
   err = esp_event_loop_create_default();
-  ESPHL_ERROR_CHECK(err, "ETH event loop error");
+  // Errcode ESP_ERR_INVALID_STATE meaning: Default event loop has already been created
+  if (err != ESP_OK && err != ESP_ERR_INVALID_STATE) {
+    ESP_LOGE(TAG, "esp_event_loop_create_default failed: %s", esp_err_to_name(err));
+    this->mark_failed();
+    return;
+  }
 
   esp_netif_config_t cfg = ESP_NETIF_DEFAULT_ETH();
   this->eth_netif_ = esp_netif_new(&cfg);
@@ -234,9 +239,11 @@ void EthernetComponent::setup() {
   ESPHL_ERROR_CHECK(err, "GOT IPv6 event handler register error");
 #endif /* USE_NETWORK_IPV6 */
 
-  /* start Ethernet driver state machine */
-  err = esp_eth_start(this->eth_handle_);
-  ESPHL_ERROR_CHECK(err, "ETH start error");
+  if (this->enable_on_boot_ == false) {
+    ESP_LOGCONFIG(TAG, "Ethernet is disabled");
+    return;
+  }
+  start_interface();
 }
 
 void EthernetComponent::loop() {
@@ -323,8 +330,10 @@ void EthernetComponent::dump_config() {
       break;
   }
 
-  ESP_LOGCONFIG(TAG, "Ethernet:");
-  this->dump_connect_params_();
+  if (this->connected_) {
+    ESP_LOGCONFIG(TAG, "Ethernet:");
+    this->dump_connect_params_();
+  }
 #ifdef USE_ETHERNET_SPI
   ESP_LOGCONFIG(TAG, "  CLK Pin: %u", this->clk_pin_);
   ESP_LOGCONFIG(TAG, "  MISO Pin: %u", this->miso_pin_);
@@ -353,7 +362,7 @@ void EthernetComponent::dump_config() {
 
 float EthernetComponent::get_setup_priority() const { return setup_priority::WIFI; }
 
-bool EthernetComponent::can_proceed() { return this->is_connected(); }
+bool EthernetComponent::can_proceed() { return !this->enable_on_boot_ || this->is_connected(); }
 
 network::IPAddresses EthernetComponent::get_ip_addresses() {
   network::IPAddresses addresses;
@@ -613,6 +622,12 @@ bool EthernetComponent::powerdown() {
     return false;
   }
   return true;
+}
+
+void EthernetComponent::start_interface() {
+  /* start Ethernet driver state machine */
+  esp_err_t err = esp_eth_start(this->eth_handle_);
+  ESPHL_ERROR_CHECK(err, "ETH start error");
 }
 
 #ifndef USE_ETHERNET_SPI

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -91,6 +91,9 @@ class EthernetComponent : public Component {
   eth_speed_t get_link_speed();
   bool powerdown();
 
+  void start_interface();
+  void set_enable_on_boot(bool enable_on_boot) { this->enable_on_boot_ = enable_on_boot; }
+
  protected:
   static void eth_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
   static void got_ip_event_handler(void *arg, esp_event_base_t event_base, int32_t event_id, void *event_data);
@@ -133,6 +136,7 @@ class EthernetComponent : public Component {
   bool started_{false};
   bool connected_{false};
   bool got_ipv4_address_{false};
+  bool enable_on_boot_{true};
 #if LWIP_IPV6
   uint8_t ipv6_count_{0};
 #endif /* LWIP_IPV6 */

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -71,12 +71,13 @@ void WiFiComponent::start() {
 
   SavedWifiSettings save{};
   if (this->pref_.load(&save)) {
-    ESP_LOGD(TAG, "Loaded saved wifi settings: %s", save.ssid);
-
-    WiFiAP sta{};
-    sta.set_ssid(save.ssid);
-    sta.set_password(save.password);
-    this->set_sta(sta);
+    if (strlen(save.ssid) > 0) {
+      ESP_LOGD(TAG, "Loaded saved wifi settings: %s", save.ssid);
+      WiFiAP sta{};
+      sta.set_ssid(save.ssid);
+      sta.set_password(save.password);
+      this->set_sta(sta);
+    }
   }
 
   if (this->has_sta()) {

--- a/esphome/components/wifi/wifi_component_esp_idf.cpp
+++ b/esphome/components/wifi/wifi_component_esp_idf.cpp
@@ -152,7 +152,8 @@ void WiFiComponent::wifi_pre_setup_() {
     return;
   }
   err = esp_event_loop_create_default();
-  if (err != ERR_OK) {
+  // Errcode ESP_ERR_INVALID_STATE meaning: Default event loop has already been created
+  if (err != ERR_OK && err != ESP_ERR_INVALID_STATE) {
     ESP_LOGE(TAG, "esp_event_loop_create_default failed: %s", esp_err_to_name(err));
     return;
   }


### PR DESCRIPTION
# What does this implement/fix?

Изменения позволяют компилировать yaml-конфиг одновременно с компонентами wifi и ethernet. Попеременная работа(при загрузке инициализируется один из интерфейсов с помощью enable on boot) проверена. При одновременной работе на уровне api возникают проблемы с коннектом и стабильная работа уже не гарантируется
Также изменения позволяют сбросить креды wifi с помощью кода ниже.  После перезагрузки механизм captive_portal запускается без проблем
```
script:
  - id: reset_wifi
    then:
      - logger.log: 'Reset wifi creds'
      - lambda: 'id(wifi_id).save_wifi_sta("", "");'
      - lambda: 'App.reboot();'
```

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [x] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
