### PR TITLE
[core] Ability of dynamically creating of components, sensors etc in setup() method of component

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -32,22 +32,24 @@ void Application::setup() {
     return a->get_actual_setup_priority() > b->get_actual_setup_priority();
   });
 
-  for (uint32_t i = 0; i < this->components_.size(); i++) {
-    Component *component = this->components_[i];
+  size_t last_components_size = this->components_.size();
 
-    size_t last_components_size = this->components_.size();
+  for (uint32_t i = 0; i < this->components_.size(); i++) {
+    // if previous component dynamically added other components in its call setup or loop, resorting of components is
+    // needed
+    if (this->components_.size() != last_components_size) {
+      std::stable_sort(this->components_.begin() + i, this->components_.end(), [](Component *a, Component *b) {
+        return a->get_actual_setup_priority() > b->get_actual_setup_priority();
+      });
+      last_components_size = this->components_.size();
+    }
+
+    Component *component = this->components_[i];
     // Update loop_component_start_time_ before calling each component during setup
     this->loop_component_start_time_ = millis();
     component->call();
     this->scheduler.process_to_add();
     this->feed_wdt();
-
-    // if current component dynamically added other components in its call setup, sorting of next components is needed
-    if (this->components_.size() != last_components_size) {
-      std::stable_sort(this->components_.begin() + i + 1, this->components_.end(), [](Component *a, Component *b) {
-        return a->get_actual_setup_priority() > b->get_actual_setup_priority();
-      });
-    }
 
     if (component->can_proceed())
       continue;

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -35,11 +35,20 @@ void Application::setup() {
   for (uint32_t i = 0; i < this->components_.size(); i++) {
     Component *component = this->components_[i];
 
+    size_t last_components_size = this->components_.size();
     // Update loop_component_start_time_ before calling each component during setup
     this->loop_component_start_time_ = millis();
     component->call();
     this->scheduler.process_to_add();
     this->feed_wdt();
+
+    // if current component dynamically added other components in its call setup, sorting of next components is needed
+    if (this->components_.size() != last_components_size) {
+      std::stable_sort(this->components_.begin() + i + 1, this->components_.end(), [](Component *a, Component *b) {
+        return a->get_actual_setup_priority() > b->get_actual_setup_priority();
+      });
+    }
+
     if (component->can_proceed())
       continue;
 


### PR DESCRIPTION
# What does this implement/fix?

I’m interested in the possibility of dynamically creating components during the initial setup at startup. I’ve discovered that dynamic component creation is possible, but for correct configuration it requires re-sorting the remaining components: in this process, the API component (sort weight 200) gains the ability to detect the newly added components (average sort weight more than 200).

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
