### PR TITLE
[JXD-245-257] Доработки компонент дисплея и меню

### DIFF
--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -287,6 +287,29 @@ void DisplayMenuComponent::show_main() {
   this->on_after_show();
 }
 
+void DisplayMenuComponent::reset_menu() {
+  bool disp_changed = false;
+
+  if (this->is_failed())
+    return;
+
+  this->process_initial_();
+
+  if (this->active_ && this->editing_)
+    this->finish_editing_();
+
+  if (this->displayed_item_ != this->root_item_) {
+    this->displayed_item_->on_leave();
+    disp_changed = true;
+  }
+
+  this->reset_();
+
+  if (disp_changed) {
+    this->displayed_item_->on_enter();
+  }
+}
+
 void DisplayMenuComponent::show() {
   if (this->is_failed())
     return;

--- a/esphome/components/display_menu_base/display_menu_base.h
+++ b/esphome/components/display_menu_base/display_menu_base.h
@@ -44,7 +44,13 @@ class DisplayMenuComponent : public Component {
   void enter();
   void back();
 
+  // Go to root of menu and show it
   void show_main();
+  // Reset menu to root item
+  void reset_menu();
+  // Check that current item is root
+  bool is_at_main() const { return this->displayed_item_ == this->root_item_; }
+
   void show();
   void hide();
 

--- a/esphome/components/graphical_display_menu/__init__.py
+++ b/esphome/components/graphical_display_menu/__init__.py
@@ -18,6 +18,7 @@ from esphome.const import (
 
 CONF_MENU_ITEM_VALUE = "menu_item_value"
 CONF_ON_REDRAW = "on_redraw"
+CONF_RESTORE_PAGE = "restore_page"
 
 graphical_display_menu_ns = cg.esphome_ns.namespace("graphical_display_menu")
 GraphicalDisplayMenu = graphical_display_menu_ns.class_(
@@ -45,6 +46,7 @@ CONFIG_SCHEMA = DISPLAY_MENU_BASE_SCHEMA.extend(
             cv.Optional(CONF_DISPLAY): cv.use_id(display.Display),
             cv.Required(CONF_FONT): cv.use_id(font.Font),
             cv.Optional(CONF_MENU_ITEM_VALUE): cv.templatable(cv.string),
+            cv.Optional(CONF_RESTORE_PAGE, default=True): cv.boolean,
             cv.Optional(CONF_FOREGROUND_COLOR): cv.use_id(color.ColorStruct),
             cv.Optional(CONF_BACKGROUND_COLOR): cv.use_id(color.ColorStruct),
             cv.Optional(CONF_ON_REDRAW): automation.validate_automation(
@@ -69,6 +71,7 @@ async def to_code(config):
 
     menu_font = await cg.get_variable(config[CONF_FONT])
     cg.add(var.set_font(menu_font))
+    cg.add(var.set_restore_page(config[CONF_RESTORE_PAGE]))
 
     if (menu_item_value_config := config.get(CONF_MENU_ITEM_VALUE, None)) is not None:
         if isinstance(menu_item_value_config, core.Lambda):

--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -70,7 +70,7 @@ void GraphicalDisplayMenu::on_before_show() {
 }
 
 void GraphicalDisplayMenu::on_before_hide() {
-  if (this->previous_display_page_ != nullptr) {
+  if (this->restore_page_ && this->previous_display_page_ != nullptr) {
     this->display_->show_page((display::DisplayPage *) this->previous_display_page_);
     this->display_->clear();
     this->update();

--- a/esphome/components/graphical_display_menu/graphical_display_menu.h
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.h
@@ -43,6 +43,7 @@ class GraphicalDisplayMenu : public display_menu_base::DisplayMenuComponent {
   template<typename V> void set_menu_item_value(V menu_item_value) { this->menu_item_value_ = menu_item_value; }
   void set_foreground_color(Color foreground_color);
   void set_background_color(Color background_color);
+  void set_restore_page(bool val) { this->restore_page_ = val; }
 
   void add_on_redraw_callback(std::function<void()> &&cb) { this->on_redraw_callbacks_.add(std::move(cb)); }
 
@@ -69,6 +70,7 @@ class GraphicalDisplayMenu : public display_menu_base::DisplayMenuComponent {
   TemplatableValue<std::string, const MenuItemValueArguments *> menu_item_value_;
   Color foreground_color_{COLOR_ON};
   Color background_color_{COLOR_OFF};
+  bool restore_page_;
 
   CallbackManager<void()> on_redraw_callbacks_{};
 };


### PR DESCRIPTION
# What does this implement/fix?

Для реализации некоторых фич устройства понадобилось добавить след функции:
- reset_menu - сброс меню до корневого без показа меню
- is_at_main - проверка, что меню на текущий момент находится в корне
- Опция restore_page у компонента graphical_display_menu в нашем случае должна быть выставлена в false, чтобы при скрытии меню не проскакивала предыдущая сохраненная страница

Проверить/посмотреть использование функций можно на ветке 
[github.com/jethome-iot/esphome-configs/tree/JXD-247-main-page](https://github.com/jethome-iot/esphome-configs/tree/JXD-247-main-page)

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
