### PR TITLE
[JXD-245] Функция печати длинных строк на нескольких строках дисплея

### DIFF
--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -592,6 +592,57 @@ void Display::print(int x, int y, BaseFont *font, TextAlign align, const char *t
 void Display::print(int x, int y, BaseFont *font, const char *text) {
   this->print(x, y, font, COLOR_ON, TextAlign::TOP_LEFT, text);
 }
+
+void Display::print_multiline(int x, int y, int width, int height, BaseFont *font, const char *text,
+                              float line_height_multiplier) {
+  std::string text_buff(text);
+  const size_t buff_size = text_buff.size();
+
+  if (buff_size == 0)
+    return;
+
+  char buff_char[2] = {0};
+  int line_y = y;
+
+  const char *last_buff_ptr = text_buff.c_str();
+
+  for (size_t symb_index = 0; symb_index < buff_size; symb_index++) {
+    size_t zero_index = symb_index + 1;
+
+    buff_char[0] = text_buff[zero_index];
+    int line_x1, line_y1, line_width, line_height;
+
+    text_buff[zero_index] = 0;
+
+    this->get_text_bounds(0, 0, last_buff_ptr, font, TextAlign::TOP_LEFT, &line_x1, &line_y1, &line_width,
+                          &line_height);
+
+    // Check that doesn't exceed height
+    if (line_y + line_height > height) {
+      break;
+    }
+
+    // Exceed width, printing, current symbol should be analyze again
+    if (line_width > width) {
+      buff_char[1] = text_buff[symb_index];
+
+      text_buff[symb_index] = 0;
+
+      this->print(x, line_y, font, last_buff_ptr);
+
+      last_buff_ptr = text_buff.c_str() + symb_index;
+      text_buff[symb_index] = buff_char[1];
+
+      symb_index--;
+      line_y += line_height_multiplier * line_height;
+    } else if (zero_index == buff_size) {
+      this->print(x, line_y, font, last_buff_ptr);
+    }
+
+    text_buff[zero_index] = buff_char[0];
+  }
+}
+
 void Display::printf(int x, int y, BaseFont *font, Color color, Color background, TextAlign align, const char *format,
                      ...) {
   va_list arg;

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -377,6 +377,19 @@ class Display : public PollingComponent {
    */
   void print(int x, int y, BaseFont *font, const char *text);
 
+  /** Print multiline `text` with the top left at [x,y] with `font`.
+   *
+   * @param x The x coordinate of the upper left corner.
+   * @param y The y coordinate of the upper left corner.
+   * @param width Max block width
+   * @param height Max block height
+   * @param font The font to draw the text with.
+   * @param text The text to draw.
+   * @param line_height_multiplier Next line y pos is line_height multiply this param
+   */
+  void print_multiline(int x, int y, int width, int height, BaseFont *font, const char *text,
+                       float line_height_multiplier = 1.0f);
+
   /** Evaluate the printf-format `format` and print the result with the anchor point at [x,y] with `font`.
    *
    * @param x The x coordinate of the text alignment anchor point.


### PR DESCRIPTION
# What does this implement/fix?

print_multiline - для возможности отображения длинного текста на нескольких строках

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
display:
  - platform: ssd1306_i2c
    id: display1
    model: "SH1106_128X64"
    address: 0x3C

    pages:
      - id: ru_page
        lambda: |-
          const auto width = it.get_width();
          const auto height = it.get_height();

          const char * text = "АБВГДЕЁЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ абвгдеёжзийклмнопрстуфхцчшщъыьэюя";
          it.print_multiline(0, 0, width, height, id(selected_font), text, 1.0);

```

## Checklist:
  - [x] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
