### PR TITLE
Add C++14 standard flag to clang-tidy configuration

### DIFF
--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -94,7 +94,7 @@ def clang_options(idedata):
             "-std=gnu++14",
         ]
     )
-    omit_flags+=("-std=c++11", "-std=gnu++11")
+    omit_flags+=("-std=c++11", "-std=gnu++11", "-std=c++14")
 
     # copy compiler flags, except those clang doesn't understand.
     cmd.extend(flag for flag in idedata["cxx_flags"] if flag not in omit_flags)

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -91,8 +91,10 @@ def clang_options(idedata):
             "-DCLANG_TIDY",
             # (esp-idf) Fix __once_callable in some libstdc++ headers
             "-D_GLIBCXX_HAVE_TLS",
+            "-std=gnu++14",
         ]
     )
+    omit_flags+=("-std=c++11", "-std=gnu++11")
 
     # copy compiler flags, except those clang doesn't understand.
     cmd.extend(flag for flag in idedata["cxx_flags"] if flag not in omit_flags)


### PR DESCRIPTION
# What does this implement/fix?

Add C++14 standard flag to clang-tidy configuration

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Code quality improvements to existing code or addition of tests
- [ ] Other
