### PR TITLE
[JXD-249] Dallas Temp Searcher naming options

### DIFF
--- a/esphome/components/dallas_temp_searcher/__init__.py
+++ b/esphome/components/dallas_temp_searcher/__init__.py
@@ -11,6 +11,9 @@ DallasTempSearcherComponent = dallas_temp_searcher_ns.class_(
 )
 
 CONF_MAX_SENSORS_NUM = "max_sensors_num"
+CONF_NAME_PREFIX = "name_prefix"
+CONF_NAME_ADDR_START_BYTE = "name_addr_start_byte"
+CONF_NAME_ADDR_STOP_BYTE = "name_addr_stop_byte"
 
 search_mode = dallas_temp_searcher_ns.enum("SearchMode", is_class=True)
 
@@ -30,11 +33,29 @@ def check_mode(config):
     if CONF_MODE in config:
         if config[CONF_MODE] == "address_map":
             MAX_SENSOR_NUM_SCHEMA(config)
+            if (
+                CONF_NAME_ADDR_START_BYTE in config
+                or CONF_NAME_ADDR_STOP_BYTE in config
+            ):
+                raise cv.Invalid(
+                    f"{CONF_NAME_ADDR_START_BYTE} and {CONF_NAME_ADDR_STOP_BYTE} params is needed only in "
+                    "all"
+                    " mode"
+                )
         elif config[CONF_MODE] == "all":
             if CONF_MAX_SENSORS_NUM in config:
                 raise cv.Invalid(
                     f"{CONF_MAX_SENSORS_NUM} param is needed only in address_map mode"
                 )
+            if (
+                CONF_NAME_ADDR_START_BYTE in config
+                and CONF_NAME_ADDR_STOP_BYTE in config
+            ):
+                if config[CONF_NAME_ADDR_START_BYTE] > config[CONF_NAME_ADDR_STOP_BYTE]:
+                    raise cv.Invalid(
+                        f"{CONF_NAME_ADDR_START_BYTE} param must be less or equal than {CONF_NAME_ADDR_STOP_BYTE}"
+                    )
+
     return config
 
 
@@ -45,6 +66,9 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_UPDATE_INTERVAL, default="60s"): cv.update_interval,
             cv.Optional(CONF_MODE, default="all"): cv.enum(SEARCH_MODE, lower=True),
             cv.Optional(CONF_MAX_SENSORS_NUM): cv.int_,
+            cv.Optional(CONF_NAME_PREFIX, default="Temp Sensor"): cv.string,
+            cv.Optional(CONF_NAME_ADDR_START_BYTE): cv.int_range(min=1, max=8),
+            cv.Optional(CONF_NAME_ADDR_STOP_BYTE): cv.int_range(min=1, max=8),
         }
     ).extend(one_wire.one_wire_device_schema().extend(groups.LIST_OF_GROUPS_SCHEMA)),
     check_mode,
@@ -59,6 +83,14 @@ async def to_code(config):
     if CONF_MAX_SENSORS_NUM in config:
         cg.add(var.set_max_sensors_num(config[CONF_MAX_SENSORS_NUM]))
     cg.add(var.set_search_mode(config[CONF_MODE]))
+
+    cg.add(var.set_name_prefix(config[CONF_NAME_PREFIX]))
+
+    if name_config := config.get(CONF_NAME_ADDR_START_BYTE):
+        cg.add(var.set_name_start_addr_byte(name_config))
+
+    if name_config := config.get(CONF_NAME_ADDR_STOP_BYTE):
+        cg.add(var.set_name_stop_addr_byte(name_config))
 
     if group_config := config.get(CONF_GROUPS):
         await groups.add_groups_to_storage(var, group_config)

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -174,10 +174,11 @@ void DallasTemperatureSearcher::set_default_parameters_(dallas_temp::DallasTempe
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_address_(const uint64_t &address) {
   EntityBaseInfo info;
   std::string address_str = format_hex(address);
-  address_str[this->name_stop_address_ * 2] = 0;
+  static const size_t HEX_CHARS_PER_BYTE = 2;
+  address_str[this->name_stop_address_ * HEX_CHARS_PER_BYTE] = 0;
 
-  info.name =
-      make_sensor_name(this->name_prefix_.c_str(), "%s", address_str.c_str() + (this->name_start_address_ - 1) * 2);
+  info.name = make_sensor_name(this->name_prefix_.c_str(), "%s",
+                               address_str.c_str() + (this->name_start_address_ - 1) * HEX_CHARS_PER_BYTE);
   info.object_id = make_sensor_object_id(address);
   return make_sensor_base_(address, info);
 }

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -12,9 +12,9 @@ static const char *const TAG = "dallas.temp.searcher";
 template<typename... Args> std::string make_sensor_name(const char *prefix, const char *format, Args... args) {
   const size_t string_buffer_size = 64;
   char string_buff[string_buffer_size];
-
-  strcpy(string_buff, prefix);
-  snprintf(string_buff + strlen(string_buff), string_buffer_size, format, args...);
+  size_t prefix_size = strlen(prefix);
+  strlcpy(string_buff, prefix, string_buffer_size);
+  snprintf(string_buff + prefix_size, string_buffer_size - prefix_size, format, args...);
 
   return std::string(string_buff);
 }
@@ -24,7 +24,8 @@ std::string make_sensor_object_id(const uint64_t &address) {
   char string_buff[string_buffer_size];
 
   strcpy(string_buff, "dallas_searcher_temp_sensor_");
-  snprintf(string_buff + strlen(string_buff), string_buffer_size, "0x%s", format_hex(address).c_str());
+  size_t cur_len = strlen(string_buff);
+  snprintf(string_buff + cur_len, string_buffer_size - cur_len, "0x%s", format_hex(address).c_str());
 
   return std::string(string_buff);
 }
@@ -193,10 +194,10 @@ dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_bas
                                                                                    const EntityBaseInfo &info) {
   auto *sensor = new dallas_temp::DallasTemperatureSensor();
   this->sensors_params_.push_back(info);
-  const auto &caсhed = this->sensors_params_.back();
+  const auto &saved_info = this->sensors_params_.back();
   sensor->set_one_wire_bus(bus_);
-  sensor->set_name(caсhed.name.c_str());
-  sensor->set_object_id(caсhed.object_id.c_str());
+  sensor->set_name(saved_info.name.c_str());
+  sensor->set_object_id(saved_info.object_id.c_str());
   sensor->set_address(address);
   set_default_parameters_(sensor);
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.cpp
@@ -9,21 +9,24 @@ namespace dallas_temp_searcher {
 
 static const char *const TAG = "dallas.temp.searcher";
 
-template<typename... Args> EntityBaseInfo make_sensor_info(const char *format, Args... args) {
+template<typename... Args> std::string make_sensor_name(const char *prefix, const char *format, Args... args) {
   const size_t string_buffer_size = 64;
   char string_buff[string_buffer_size];
 
-  EntityBaseInfo entity_base_info;
-
-  strcpy(string_buff, "Temp Sensor ");
+  strcpy(string_buff, prefix);
   snprintf(string_buff + strlen(string_buff), string_buffer_size, format, args...);
-  entity_base_info.name = string_buff;
+
+  return std::string(string_buff);
+}
+
+std::string make_sensor_object_id(const uint64_t &address) {
+  const size_t string_buffer_size = 64;
+  char string_buff[string_buffer_size];
 
   strcpy(string_buff, "dallas_searcher_temp_sensor_");
-  snprintf(string_buff + strlen(string_buff), string_buffer_size, format, args...);
-  entity_base_info.object_id = string_buff;
+  snprintf(string_buff + strlen(string_buff), string_buffer_size, "0x%s", format_hex(address).c_str());
 
-  return entity_base_info;
+  return std::string(string_buff);
 }
 
 void DallasTemperatureSearcher::setup() {
@@ -168,26 +171,35 @@ void DallasTemperatureSearcher::set_default_parameters_(dallas_temp::DallasTempe
 }
 
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_address_(const uint64_t &address) {
-  EntityBaseInfo info = make_sensor_info("0x%s", format_hex(address).c_str());
-  return make_sensor_base_(address, std::move(info));
+  EntityBaseInfo info;
+  std::string address_str = format_hex(address);
+  address_str[this->name_stop_address_ * 2] = 0;
+
+  info.name =
+      make_sensor_name(this->name_prefix_.c_str(), "%s", address_str.c_str() + (this->name_start_address_ - 1) * 2);
+  info.object_id = make_sensor_object_id(address);
+  return make_sensor_base_(address, info);
 }
 
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_with_number_(const uint64_t &address,
                                                                                           uint32_t number) {
-  EntityBaseInfo info = make_sensor_info("number_%d", number);
-  return make_sensor_base_(address, std::move(info));
+  EntityBaseInfo info;
+  info.name = make_sensor_name(this->name_prefix_.c_str(), "%d", number);
+  info.object_id = make_sensor_object_id(address);
+  return make_sensor_base_(address, info);
 }
 
 dallas_temp::DallasTemperatureSensor *DallasTemperatureSearcher::make_sensor_base_(const uint64_t &address,
-                                                                                   EntityBaseInfo &&info) {
+                                                                                   const EntityBaseInfo &info) {
   auto *sensor = new dallas_temp::DallasTemperatureSensor();
+  this->sensors_params_.push_back(info);
+  const auto &caсhed = this->sensors_params_.back();
   sensor->set_one_wire_bus(bus_);
-  sensor->set_name(info.name.c_str());
-  sensor->set_object_id(info.object_id.c_str());
+  sensor->set_name(caсhed.name.c_str());
+  sensor->set_object_id(caсhed.object_id.c_str());
   sensor->set_address(address);
   set_default_parameters_(sensor);
 
-  this->sensors_params_.push_back(std::move(info));
   return sensor;
 }
 

--- a/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
+++ b/esphome/components/dallas_temp_searcher/dallas_temp_searcher.h
@@ -36,12 +36,17 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
 
   void set_max_sensors_num(size_t max_num) { this->max_sensors_num_ = max_num; }
 
+  void set_name_prefix(const char *prefix) { this->name_prefix_ = StringRef(prefix); }
+
+  void set_name_start_addr_byte(uint8_t byte) { this->name_start_address_ = byte; }
+  void set_name_stop_addr_byte(uint8_t byte) { this->name_stop_address_ = byte; }
+
  protected:
   void set_default_parameters_(dallas_temp::DallasTemperatureSensor *sensor);
   void restore_sensors_count_();
   bool restore_address_data_(ESPPreferenceObject &obj);
 
-  dallas_temp::DallasTemperatureSensor *make_sensor_base_(const uint64_t &address, EntityBaseInfo &&info);
+  dallas_temp::DallasTemperatureSensor *make_sensor_base_(const uint64_t &address, const EntityBaseInfo &info);
   dallas_temp::DallasTemperatureSensor *make_sensor_with_address_(const uint64_t &address);
   dallas_temp::DallasTemperatureSensor *make_sensor_with_number_(const uint64_t &address, uint32_t number);
 
@@ -57,6 +62,10 @@ class DallasTemperatureSearcher : public Component, public one_wire::OneWireDevi
   SearchMode search_mode_ = SearchMode::ALL;
   ESPPreferenceObject sensors_count_pref_;
   std::vector<ESPPreferenceObject> addresses_pref_;
+  StringRef name_prefix_;
+
+  uint8_t name_start_address_ = 1;
+  uint8_t name_stop_address_ = 8;
 };
 
 }  // namespace dallas_temp_searcher


### PR DESCRIPTION
# What does this implement/fix?

Add Dallas Temp Searcher naming options:
name_prefix:
name_addr_start_byte:
name_addr_stop_byte:

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
dallas_temp_searcher:
  id: dallas_searcher_id
  update_interval: 20s
  one_wire_id: one_wire1_id
  mode: all
  name_prefix: "TS 0x"
  name_addr_start_byte: 5
  name_addr_stop_byte: 7
  groups:
    - temperature_group_id
    - onewire_group_id
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
