### PR TITLE
Fix logger string to ESPJHome

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -1054,7 +1054,7 @@ def run_esphome(argv):
             _LOGGER.error(e, exc_info=args.verbose)
             return 1
 
-    _LOGGER.info("ESPHome %s", const.__version__)
+    _LOGGER.info("ESPJHome %s", const.__version__)
 
     for conf_path in args.configuration:
         if any(os.path.basename(conf_path) == x for x in SECRETS_FILES):


### PR DESCRIPTION
# What does this implement/fix?

This pull request includes a small change to the logging message in the `run_esphome` function within `esphome/__main__.py`. The change updates the log to display "ESPJHome" instead of "ESPHome" when printing the version information.

## Types of changes

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other
