### PR TITLE
[JXD-296] Application rollback

### DIFF
--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -20,11 +20,10 @@ CONF_ON_BEGIN = "on_begin"
 CONF_ON_END = "on_end"
 CONF_ON_PROGRESS = "on_progress"
 CONF_ON_STATE_CHANGE = "on_state_change"
-OTA_ROLLBACK_ID = "ota_rollback_id"
+
 
 ota_ns = cg.esphome_ns.namespace("ota")
 OTAComponent = ota_ns.class_("OTAComponent", cg.Component)
-OTARollback = ota_ns.class_("OTARollback", cg.Component)
 OTAState = ota_ns.enum("OTAState")
 OTAAbortTrigger = ota_ns.class_("OTAAbortTrigger", automation.Trigger.template())
 OTAEndTrigger = ota_ns.class_("OTAEndTrigger", automation.Trigger.template())
@@ -84,9 +83,6 @@ BASE_OTA_SCHEMA = cv.Schema(
 @coroutine_with_priority(54.0)
 async def to_code(config):
     cg.add_define("USE_OTA")
-
-    var = cg.new_Pvariable(cv.declare_id(OTARollback)(OTA_ROLLBACK_ID))
-    await cg.register_component(var, config)
 
     if CORE.is_esp32 and CORE.using_arduino:
         cg.add_library("Update", None)

--- a/esphome/components/ota/__init__.py
+++ b/esphome/components/ota/__init__.py
@@ -20,10 +20,11 @@ CONF_ON_BEGIN = "on_begin"
 CONF_ON_END = "on_end"
 CONF_ON_PROGRESS = "on_progress"
 CONF_ON_STATE_CHANGE = "on_state_change"
-
+OTA_ROLLBACK_ID = "ota_rollback_id"
 
 ota_ns = cg.esphome_ns.namespace("ota")
 OTAComponent = ota_ns.class_("OTAComponent", cg.Component)
+OTARollback = ota_ns.class_("OTARollback", cg.Component)
 OTAState = ota_ns.enum("OTAState")
 OTAAbortTrigger = ota_ns.class_("OTAAbortTrigger", automation.Trigger.template())
 OTAEndTrigger = ota_ns.class_("OTAEndTrigger", automation.Trigger.template())
@@ -83,6 +84,9 @@ BASE_OTA_SCHEMA = cv.Schema(
 @coroutine_with_priority(54.0)
 async def to_code(config):
     cg.add_define("USE_OTA")
+
+    var = cg.new_Pvariable(cv.declare_id(OTARollback)(OTA_ROLLBACK_ID))
+    await cg.register_component(var, config)
 
     if CORE.is_esp32 and CORE.using_arduino:
         cg.add_library("Update", None)

--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -58,8 +58,8 @@ class OTABackend {
   virtual void abort() = 0;
   virtual bool supports_compression() = 0;
   virtual bool is_rollback_available() { return false; }
-  virtual void make_rollback() = 0;
-  virtual void mark_app_valid() = 0;
+  virtual void make_rollback(){};
+  virtual void mark_app_valid(){};
 };
 
 class OTAComponent : public Component {
@@ -94,17 +94,6 @@ OTAGlobalCallback *get_global_ota_callback();
 void register_ota_platform(OTAComponent *ota_caller);
 #endif
 std::unique_ptr<ota::OTABackend> make_ota_backend();
-
-class OTARollback : public Component {
- public:
-  float get_setup_priority() const { return setup_priority::AFTER_WIFI; }
-  void setup() override {
-    std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
-    backend->mark_app_valid();
-  }
-
- protected:
-};
 
 }  // namespace ota
 }  // namespace esphome

--- a/esphome/components/ota/ota_backend.h
+++ b/esphome/components/ota/ota_backend.h
@@ -57,6 +57,9 @@ class OTABackend {
   virtual OTAResponseTypes end() = 0;
   virtual void abort() = 0;
   virtual bool supports_compression() = 0;
+  virtual bool is_rollback_available() { return false; }
+  virtual void make_rollback() = 0;
+  virtual void mark_app_valid() = 0;
 };
 
 class OTAComponent : public Component {
@@ -91,6 +94,17 @@ OTAGlobalCallback *get_global_ota_callback();
 void register_ota_platform(OTAComponent *ota_caller);
 #endif
 std::unique_ptr<ota::OTABackend> make_ota_backend();
+
+class OTARollback : public Component {
+ public:
+  float get_setup_priority() const { return setup_priority::AFTER_WIFI; }
+  void setup() override {
+    std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
+    backend->mark_app_valid();
+  }
+
+ protected:
+};
 
 }  // namespace ota
 }  // namespace esphome

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -113,9 +113,9 @@ void IDFOTABackend::abort() {
 
 bool IDFOTABackend::is_rollback_available() { return esp_ota_check_rollback_is_possible(); }
 
-void IDFOTABackend::make_rollback() {}
+void IDFOTABackend::make_rollback() { esp_ota_mark_app_invalid_rollback_and_reboot(); }
 
-void IDFOTABackend::mark_app_valid() {}
+void IDFOTABackend::mark_app_valid() { esp_ota_mark_app_valid_cancel_rollback(); }
 
 }  // namespace ota
 }  // namespace esphome

--- a/esphome/components/ota/ota_backend_esp_idf.cpp
+++ b/esphome/components/ota/ota_backend_esp_idf.cpp
@@ -111,6 +111,12 @@ void IDFOTABackend::abort() {
   this->update_handle_ = 0;
 }
 
+bool IDFOTABackend::is_rollback_available() { return esp_ota_check_rollback_is_possible(); }
+
+void IDFOTABackend::make_rollback() {}
+
+void IDFOTABackend::mark_app_valid() {}
+
 }  // namespace ota
 }  // namespace esphome
 #endif

--- a/esphome/components/ota/ota_backend_esp_idf.h
+++ b/esphome/components/ota/ota_backend_esp_idf.h
@@ -18,6 +18,9 @@ class IDFOTABackend : public OTABackend {
   OTAResponseTypes end() override;
   void abort() override;
   bool supports_compression() override { return false; }
+  bool is_rollback_available() override;
+  void make_rollback() override;
+  void mark_app_valid() override;
 
  private:
   esp_ota_handle_t update_handle_{0};

--- a/esphome/components/ota_rollback/__init__.py
+++ b/esphome/components/ota_rollback/__init__.py
@@ -5,7 +5,7 @@ from esphome.const import CONF_ID
 
 AUTO_LOAD = ["ota"]
 
-ota_ns = cg.esphome_ns.namespace("ota")
+ota_ns = cg.esphome_ns.namespace("ota_rollback")
 OTARollback = ota_ns.class_("OTARollback", cg.Component)
 
 CONFIG_SCHEMA = cv.All(

--- a/esphome/components/ota_rollback/__init__.py
+++ b/esphome/components/ota_rollback/__init__.py
@@ -1,0 +1,27 @@
+import esphome.codegen as cg
+from esphome.components import esp32
+import esphome.config_validation as cv
+from esphome.const import CONF_ID
+
+AUTO_LOAD = ["ota"]
+
+ota_ns = cg.esphome_ns.namespace("ota")
+OTARollback = ota_ns.class_("OTARollback", cg.Component)
+
+CONFIG_SCHEMA = cv.All(
+    cv.Schema(
+        {
+            cv.GenerateID(): cv.declare_id(OTARollback),
+        }
+    ),
+    cv.only_with_esp_idf,
+)
+
+
+async def to_code(config):
+    esp32.add_idf_sdkconfig_option(
+        "CONFIG_BOOTLOADER_APP_ROLLBACK_ENABLE",
+        True,
+    )
+    var = cg.new_Pvariable(config[CONF_ID])
+    await cg.register_component(var, config)

--- a/esphome/components/ota_rollback/ota_rollback.cpp
+++ b/esphome/components/ota_rollback/ota_rollback.cpp
@@ -2,7 +2,7 @@
 #include "esphome/core/log.h"
 
 namespace esphome {
-namespace ota {
+namespace ota_rollback {
 static const char *const TAG = "ota_rollback";
 
 void OTARollback::setup() {
@@ -19,5 +19,5 @@ void OTARollback::rollback() {
   backend->make_rollback();
 };
 
-}  // namespace ota
+}  // namespace ota_rollback
 }  // namespace esphome

--- a/esphome/components/ota_rollback/ota_rollback.cpp
+++ b/esphome/components/ota_rollback/ota_rollback.cpp
@@ -1,0 +1,5 @@
+#include "ota_rollback.h"
+
+namespace esphome {
+namespace ota {}  // namespace ota
+}  // namespace esphome

--- a/esphome/components/ota_rollback/ota_rollback.cpp
+++ b/esphome/components/ota_rollback/ota_rollback.cpp
@@ -1,5 +1,23 @@
 #include "ota_rollback.h"
+#include "esphome/core/log.h"
 
 namespace esphome {
-namespace ota {}  // namespace ota
+namespace ota {
+static const char *const TAG = "ota_rollback";
+
+void OTARollback::setup() {
+  std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
+  backend->mark_app_valid();
+  this->rollback_available_ = backend->is_rollback_available();
+}
+
+bool OTARollback::is_available() { return this->rollback_available_; }
+
+void OTARollback::rollback() {
+  ESP_LOGI(TAG, "rollback process");
+  std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
+  backend->make_rollback();
+};
+
+}  // namespace ota
 }  // namespace esphome

--- a/esphome/components/ota_rollback/ota_rollback.cpp
+++ b/esphome/components/ota_rollback/ota_rollback.cpp
@@ -6,7 +6,7 @@ namespace ota_rollback {
 static const char *const TAG = "ota_rollback";
 
 void OTARollback::setup() {
-  std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
+  std::unique_ptr<ota::OTABackend> backend = ota::make_ota_backend();
   backend->mark_app_valid();
   this->rollback_available_ = backend->is_rollback_available();
 }
@@ -14,10 +14,12 @@ void OTARollback::setup() {
 bool OTARollback::is_available() { return this->rollback_available_; }
 
 void OTARollback::rollback() {
+  if (!this->rollback_available_)
+    return;
   ESP_LOGI(TAG, "rollback process");
-  std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
+  std::unique_ptr<ota::OTABackend> backend = ota::make_ota_backend();
   backend->make_rollback();
-};
+}
 
 }  // namespace ota_rollback
 }  // namespace esphome

--- a/esphome/components/ota_rollback/ota_rollback.cpp
+++ b/esphome/components/ota_rollback/ota_rollback.cpp
@@ -11,6 +11,8 @@ void OTARollback::setup() {
   this->rollback_available_ = backend->is_rollback_available();
 }
 
+void OTARollback::dump_config() { ESP_LOGCONFIG(TAG, this->rollback_available_ ? "available" : "unavailable"); }
+
 bool OTARollback::is_available() { return this->rollback_available_; }
 
 void OTARollback::rollback() {

--- a/esphome/components/ota_rollback/ota_rollback.h
+++ b/esphome/components/ota_rollback/ota_rollback.h
@@ -10,6 +10,7 @@ class OTARollback : public Component {
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
   void setup() override;
+  void dump_config() override;
 
   bool is_available();
   void rollback();

--- a/esphome/components/ota_rollback/ota_rollback.h
+++ b/esphome/components/ota_rollback/ota_rollback.h
@@ -7,22 +7,15 @@ namespace ota {
 
 class OTARollback : public Component {
  public:
-  float get_setup_priority() const { return setup_priority::AFTER_WIFI; }
+  float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
-  void setup() override {
-    std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
-    backend->mark_app_valid();
-  }
+  void setup() override;
 
-  bool is_available() {
-    std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
-    return backend->is_rollback_available();
-  }
+  bool is_available();
+  void rollback();
 
-  void rollback() {
-    std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
-    backend->make_rollback();
-  };
+ protected:
+  bool rollback_available_;
 };
 
 }  // namespace ota

--- a/esphome/components/ota_rollback/ota_rollback.h
+++ b/esphome/components/ota_rollback/ota_rollback.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "esphome/components/ota/ota_backend.h"
+
+namespace esphome {
+namespace ota {
+
+class OTARollback : public Component {
+ public:
+  float get_setup_priority() const { return setup_priority::AFTER_WIFI; }
+
+  void setup() override {
+    std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
+    backend->mark_app_valid();
+  }
+
+  bool is_available() {
+    std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
+    return backend->is_rollback_available();
+  }
+
+  void rollback() {
+    std::unique_ptr<ota::OTABackend> backend = make_ota_backend();
+    backend->make_rollback();
+  };
+};
+
+}  // namespace ota
+}  // namespace esphome

--- a/esphome/components/ota_rollback/ota_rollback.h
+++ b/esphome/components/ota_rollback/ota_rollback.h
@@ -3,7 +3,7 @@
 #include "esphome/components/ota/ota_backend.h"
 
 namespace esphome {
-namespace ota {
+namespace ota_rollback {
 
 class OTARollback : public Component {
  public:
@@ -18,5 +18,5 @@ class OTARollback : public Component {
   bool rollback_available_;
 };
 
-}  // namespace ota
+}  // namespace ota_rollback
 }  // namespace esphome

--- a/tests/components/ota_rollback/common.yaml
+++ b/tests/components/ota_rollback/common.yaml
@@ -1,0 +1,8 @@
+wifi:
+  ssid: MySSID
+  password: password1
+
+ota_rollback:
+
+ota:
+  - platform: esphome

--- a/tests/components/ota_rollback/test.esp32-idf.yaml
+++ b/tests/components/ota_rollback/test.esp32-idf.yaml
@@ -1,0 +1,1 @@
+<<: !include common.yaml


### PR DESCRIPTION
# What does this implement/fix?

Possibility to roll back the firmware to the previous version. If the new firmware is not started correctly, the rollback occurs automatically

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
ota_rollback:
  id: rollback_id

graphical_display_menu:
  items:
            - type: menu
              text: "Rollback"
              items:
                - type: label
                  text: !lambda |-
                    if (id(rollback_id).is_available()) {
                      return "Rollback?";
                    }
                    return "No rollback";

                - type: command
                  text: !lambda |-
                    if (id(rollback_id).is_available()) {
                      return "Yes";
                    }
                    return "";

                  on_value:
                    - lambda: id(rollback_id).rollback();
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
