### PR TITLE
[JXD-302] http updater custom manifest parser

### DIFF
--- a/esphome/components/http_request/update/__init__.py
+++ b/esphome/components/http_request/update/__init__.py
@@ -14,7 +14,13 @@ HttpRequestUpdate = http_request_ns.class_(
     "HttpRequestUpdate", update.UpdateEntity, cg.PollingComponent
 )
 
+UpdateManifestParserInterface = http_request_ns.class_("UpdateManifestParserInterface")
+DefaultUpdateManifestParser = http_request_ns.class_(
+    "DefaultUpdateManifestParser", UpdateManifestParserInterface
+)
+
 CONF_OTA_ID = "ota_id"
+CONF_PARSER_ID = "parser_id"
 
 CONFIG_SCHEMA = (
     update.update_schema(HttpRequestUpdate)
@@ -23,6 +29,7 @@ CONFIG_SCHEMA = (
             cv.GenerateID(CONF_OTA_ID): cv.use_id(OtaHttpRequestComponent),
             cv.GenerateID(CONF_HTTP_REQUEST_ID): cv.use_id(HttpRequestComponent),
             cv.Required(CONF_SOURCE): cv.url,
+            cv.Optional(CONF_PARSER_ID): cv.use_id(UpdateManifestParserInterface),
         }
     )
     .extend(cv.polling_component_schema("6h"))
@@ -41,3 +48,13 @@ async def to_code(config):
     cg.add_define("USE_OTA_STATE_CALLBACK")
 
     await cg.register_component(var, config)
+
+    parser = None
+    if parser_id := config.get(CONF_PARSER_ID):
+        parser = await cg.get_variable(parser_id)
+    else:
+        parser = cg.new_Pvariable(
+            cv.declare_id(DefaultUpdateManifestParser)("update_manifest_parser_id")
+        )
+
+    cg.add(var.set_manifest_parser(parser))

--- a/esphome/components/http_request/update/__init__.py
+++ b/esphome/components/http_request/update/__init__.py
@@ -54,7 +54,9 @@ async def to_code(config):
         parser = await cg.get_variable(parser_id)
     else:
         parser = cg.new_Pvariable(
-            cv.declare_id(DefaultUpdateManifestParser)("update_manifest_parser_id")
+            cv.declare_id(DefaultUpdateManifestParser)(
+                cv.GenerateID("update_manifest_parser_id")
+            )
         )
 
     cg.add(var.set_manifest_parser(parser))

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -20,6 +20,47 @@ static const char *const TAG = "http_request.update";
 
 static const size_t MAX_READ_SIZE = 256;
 
+bool DefaultUpdateManifestParser::parse(const std::string &data, update::UpdateInfo &info) {
+  bool result = json::parse_json(data, [&info](JsonObject root) -> bool {
+    if (!root.containsKey("name") || !root.containsKey("version") || !root.containsKey("builds")) {
+      ESP_LOGE(TAG, "Manifest does not contain required fields");
+      return false;
+    }
+    info.title = root["name"].as<std::string>();
+    info.latest_version = root["version"].as<std::string>();
+
+    for (auto build : root["builds"].as<JsonArray>()) {
+      if (!build.containsKey("chipFamily")) {
+        ESP_LOGE(TAG, "Manifest does not contain required fields");
+        return false;
+      }
+      if (build["chipFamily"] == ESPHOME_VARIANT) {
+        if (!build.containsKey("ota")) {
+          ESP_LOGE(TAG, "Manifest does not contain required fields");
+          return false;
+        }
+        auto ota = build["ota"];
+        if (!ota.containsKey("path") || !ota.containsKey("md5")) {
+          ESP_LOGE(TAG, "Manifest does not contain required fields");
+          return false;
+        }
+        info.firmware_url = ota["path"].as<std::string>();
+        info.md5 = ota["md5"].as<std::string>();
+
+        if (ota.containsKey("summary"))
+          info.summary = ota["summary"].as<std::string>();
+        if (ota.containsKey("release_url"))
+          info.release_url = ota["release_url"].as<std::string>();
+
+        return true;
+      }
+    }
+    return false;
+  });
+
+  return result;
+}
+
 void HttpRequestUpdate::setup() {
   this->ota_parent_->add_on_state_callback([this](ota::OTAState state, float progress, uint8_t err) {
     if (state == ota::OTAState::OTA_IN_PROGRESS) {
@@ -80,42 +121,12 @@ void HttpRequestUpdate::update_task(void *params) {
     container->end();
     container.reset();  // Release ownership of the container's shared_ptr
 
-    valid = json::parse_json(response, [this_update](JsonObject root) -> bool {
-      if (!root.containsKey("name") || !root.containsKey("version") || !root.containsKey("builds")) {
-        ESP_LOGE(TAG, "Manifest does not contain required fields");
-        return false;
-      }
-      this_update->update_info_.title = root["name"].as<std::string>();
-      this_update->update_info_.latest_version = root["version"].as<std::string>();
-
-      for (auto build : root["builds"].as<JsonArray>()) {
-        if (!build.containsKey("chipFamily")) {
-          ESP_LOGE(TAG, "Manifest does not contain required fields");
-          return false;
-        }
-        if (build["chipFamily"] == ESPHOME_VARIANT) {
-          if (!build.containsKey("ota")) {
-            ESP_LOGE(TAG, "Manifest does not contain required fields");
-            return false;
-          }
-          auto ota = build["ota"];
-          if (!ota.containsKey("path") || !ota.containsKey("md5")) {
-            ESP_LOGE(TAG, "Manifest does not contain required fields");
-            return false;
-          }
-          this_update->update_info_.firmware_url = ota["path"].as<std::string>();
-          this_update->update_info_.md5 = ota["md5"].as<std::string>();
-
-          if (ota.containsKey("summary"))
-            this_update->update_info_.summary = ota["summary"].as<std::string>();
-          if (ota.containsKey("release_url"))
-            this_update->update_info_.release_url = ota["release_url"].as<std::string>();
-
-          return true;
-        }
-      }
-      return false;
-    });
+    if (this_update->parser_ == nullptr) {
+      auto default_parser = std::make_unique<DefaultUpdateManifestParser>();
+      valid = default_parser->parse(response, this_update->update_info_);
+    } else {
+      valid = this_update->parser_->parse(response, this_update->update_info_);
+    }
   }
 
   if (!valid) {

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -121,12 +121,10 @@ void HttpRequestUpdate::update_task(void *params) {
     container->end();
     container.reset();  // Release ownership of the container's shared_ptr
 
-    if (this_update->parser_ == nullptr) {
-      auto default_parser = std::make_unique<DefaultUpdateManifestParser>();
-      valid = default_parser->parse(response, this_update->update_info_);
-    } else {
-      valid = this_update->parser_->parse(response, this_update->update_info_);
-    }
+    if (this_update->parser_ == nullptr)
+      UPDATE_RETURN;
+
+    valid = this_update->parser_->parse(response, this_update->update_info_);
   }
 
   if (!valid) {

--- a/esphome/components/http_request/update/http_request_update.cpp
+++ b/esphome/components/http_request/update/http_request_update.cpp
@@ -121,8 +121,10 @@ void HttpRequestUpdate::update_task(void *params) {
     container->end();
     container.reset();  // Release ownership of the container's shared_ptr
 
-    if (this_update->parser_ == nullptr)
+    if (this_update->parser_ == nullptr) {
+      ESP_LOGE(TAG, "Parser is null. Cannot process the update manifest");
       UPDATE_RETURN;
+    }
 
     valid = this_update->parser_->parse(response, this_update->update_info_);
   }

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -16,12 +16,12 @@ namespace http_request {
 
 class UpdateManifestParserInterface {
  public:
-  virtual bool parse(const StringRef &manifest_json, UpdateInfo &info) = 0;
+  virtual bool parse(const std::string &data, update::UpdateInfo &info) = 0;
 };
 
 class DefaultUpdateManifestParser : public UpdateManifestParserInterface {
  public:
-  bool parse(const StringRef &manifest_json, UpdateInfo &info) override;
+  bool parse(const std::string &data, update::UpdateInfo &info) override;
 };
 
 class HttpRequestUpdate : public update::UpdateEntity, public PollingComponent {

--- a/esphome/components/http_request/update/http_request_update.h
+++ b/esphome/components/http_request/update/http_request_update.h
@@ -14,6 +14,16 @@
 namespace esphome {
 namespace http_request {
 
+class UpdateManifestParserInterface {
+ public:
+  virtual bool parse(const StringRef &manifest_json, UpdateInfo &info) = 0;
+};
+
+class DefaultUpdateManifestParser : public UpdateManifestParserInterface {
+ public:
+  bool parse(const StringRef &manifest_json, UpdateInfo &info) override;
+};
+
 class HttpRequestUpdate : public update::UpdateEntity, public PollingComponent {
  public:
   void setup() override;
@@ -29,10 +39,13 @@ class HttpRequestUpdate : public update::UpdateEntity, public PollingComponent {
 
   float get_setup_priority() const override { return setup_priority::AFTER_WIFI; }
 
+  void set_manifest_parser(UpdateManifestParserInterface *parser) { this->parser_ = parser; }
+
  protected:
   HttpRequestComponent *request_parent_;
   OtaHttpRequestComponent *ota_parent_;
   std::string source_url_;
+  UpdateManifestParserInterface *parser_{nullptr};
 
   static void update_task(void *params);
 #ifdef USE_ESP32


### PR DESCRIPTION
# What does this implement/fix?

Ability to set your own update manifest parser. By default, the default parser is set

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
update:
  - platform: http_request
    name: None
    id: update_http_request
    source: https://fw.jethome.ru/api/devices/jxd-r6-e1eth-lcd/info
    update_interval: 20s
    parser_id: jethome_parser_id

jethome_manifest_parser:
  id: jethome_parser_id
  type: stand
  base_url: "https://fw.jethome.ru"

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
