### PR TITLE
[JXD-305] All menu items can have own items

### DIFF
--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -225,7 +225,9 @@ void DisplayMenuComponent::enter() {
         case MENU_ITEM_SELECT:
         case MENU_ITEM_SWITCH:
         case MENU_ITEM_CUSTOM:
-          if (item->get_immediate_edit()) {
+          if (item->has_internal_items()) {
+            changed = this->enter_menu_();
+          } else if (item->get_immediate_edit()) {
             changed = item->select_next();
           } else {
             this->editing_ = true;
@@ -395,7 +397,7 @@ bool DisplayMenuComponent::cursor_down_() {
 
 bool DisplayMenuComponent::enter_menu_() {
   this->displayed_item_->on_leave();
-  this->displayed_item_ = static_cast<MenuItemMenu *>(this->get_selected_item_());
+  this->displayed_item_ = this->get_selected_item_();
   this->selection_stack_.emplace_front(this->top_index_, this->cursor_index_);
   this->cursor_index_ = this->top_index_ = 0;
   this->displayed_item_->on_enter();

--- a/esphome/components/display_menu_base/display_menu_base.h
+++ b/esphome/components/display_menu_base/display_menu_base.h
@@ -93,7 +93,7 @@ class DisplayMenuComponent : public Component {
   bool right_for_menu_enter_opt_{true};
   MenuItemMenu *root_item_{nullptr};
 
-  MenuItemMenu *displayed_item_{nullptr};
+  MenuItem *displayed_item_{nullptr};
   uint8_t top_index_{0};
   uint8_t cursor_index_{0};
   std::forward_list<std::pair<uint8_t, uint8_t>> selection_stack_{};

--- a/esphome/components/display_menu_base/menu_item.h
+++ b/esphome/components/display_menu_base/menu_item.h
@@ -49,8 +49,8 @@ using value_getter_t = std::function<std::string(const MenuItem *)>;
 class MenuItem {
  public:
   explicit MenuItem(MenuItemType t) : item_type_(t) {}
-  void set_parent(MenuItemMenu *parent) { this->parent_ = parent; }
-  MenuItemMenu *get_parent() { return this->parent_; }
+  void set_parent(MenuItem *parent) { this->parent_ = parent; }
+  MenuItem *get_parent() { return this->parent_; }
   MenuItemType get_type() const { return this->item_type_; }
   template<typename V> void set_text(V val) { this->text_ = val; }
   void add_on_enter_callback(std::function<void()> &&cb) { this->on_enter_callbacks_.add(std::move(cb)); }
@@ -59,8 +59,24 @@ class MenuItem {
 
   std::string get_text() const { return const_cast<MenuItem *>(this)->text_.value(this); }
   virtual bool get_immediate_edit() const { return false; }
+
   virtual bool has_value() const { return false; }
   virtual std::string get_value_text() const { return ""; }
+
+  void set_internal_items_flag(bool val) { this->has_internal_items_ = val; }
+  bool has_internal_items() { return this->has_internal_items_; }
+
+  void add_item(MenuItem *item) {
+    item->set_parent(this);
+    this->items_.push_back(item);
+  }
+
+  void add_generated_items(MenuItem *item) {
+    item->set_parent(this);
+    this->items_.push_back(item);
+  }
+  size_t items_size() const { return this->items_.size(); }
+  MenuItem *get_item(size_t i) const { return this->items_[i]; }
 
   virtual bool select_next() { return false; }
   virtual bool select_prev() { return false; }
@@ -72,12 +88,15 @@ class MenuItem {
   void on_value_();
 
   MenuItemType item_type_;
-  MenuItemMenu *parent_{nullptr};
+  MenuItem *parent_{nullptr};
   TemplatableValue<std::string, const MenuItem *> text_;
 
   CallbackManager<void()> on_enter_callbacks_{};
   CallbackManager<void()> on_leave_callbacks_{};
   CallbackManager<void()> on_value_callbacks_{};
+
+  std::vector<MenuItem *> items_;
+  bool has_internal_items_{false};
 };
 
 class MenuItemValueBase : public MenuItem {
@@ -94,24 +113,11 @@ class MenuItemValueBase : public MenuItem {
 class MenuItemMenu : public MenuItemValueBase {
  public:
   explicit MenuItemMenu() : MenuItemValueBase(MENU_ITEM_MENU) {}
-  void add_item(MenuItem *item) {
-    item->set_parent(this);
-    this->items_.push_back(item);
-  }
-
-  void add_generated_items(MenuItem *item) {
-    item->set_parent(this);
-    this->items_.push_back(item);
-  }
-  size_t items_size() const { return this->items_.size(); }
-  MenuItem *get_item(size_t i) const { return this->items_[i]; }
-
 #ifdef USE_GROUPS
   void add_group(groups::Group *group) { this->groups_.push_back(group); }
   const std::vector<groups::Group *> &groups() { return groups_; }
 #endif
  protected:
-  std::vector<MenuItem *> items_;
 #ifdef USE_GROUPS
   std::vector<groups::Group *> groups_;
 #endif

--- a/esphome/components/display_menu_base/menu_item.h
+++ b/esphome/components/display_menu_base/menu_item.h
@@ -71,10 +71,6 @@ class MenuItem {
     this->items_.push_back(item);
   }
 
-  void add_generated_items(MenuItem *item) {
-    item->set_parent(this);
-    this->items_.push_back(item);
-  }
   size_t items_size() const { return this->items_.size(); }
   MenuItem *get_item(size_t i) const { return this->items_[i]; }
 
@@ -113,6 +109,10 @@ class MenuItemValueBase : public MenuItem {
 class MenuItemMenu : public MenuItemValueBase {
  public:
   explicit MenuItemMenu() : MenuItemValueBase(MENU_ITEM_MENU) {}
+  void add_generated_items(MenuItem *item) {
+    item->set_parent(this);
+    this->items_.push_back(item);
+  }
 #ifdef USE_GROUPS
   void add_group(groups::Group *group) { this->groups_.push_back(group); }
   const std::vector<groups::Group *> &groups() { return groups_; }

--- a/esphome/components/display_menu_render_base/__init__.py
+++ b/esphome/components/display_menu_render_base/__init__.py
@@ -36,28 +36,42 @@ DISPLAY_MENU_RENDER_BASE_SCHEMA = cv.Schema(
 
 CONF_ENT_TYPE = "ent_type"
 
+SWITCH_BASE_RENDER_SCHEMA = DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+    {
+        cv.Optional(CONF_ON_TEXT, default="On"): cv.string_strict,
+        cv.Optional(CONF_OFF_TEXT, default="Off"): cv.string_strict,
+    }
+)
+SENSOR_BASE_RENDER_SCHEMA = DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+    {
+        cv.Optional(CONF_NO_DATA_TEXT, default="Nan"): cv.string_strict,
+        cv.Optional(CONF_ACCURACY, default=-1): cv.int_,
+    }
+)
+
+BINARY_SENSOR_BASE_RENDER_SCHEMA = DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+    {
+        cv.Optional(CONF_ON_TEXT, default="On"): cv.string_strict,
+        cv.Optional(CONF_OFF_TEXT, default="Off"): cv.string_strict,
+        cv.Optional(CONF_NO_DATA_TEXT, default="Nan"): cv.string_strict,
+    }
+)
+
 BASE_RENDER_SCHEMA = cv.typed_schema(
     {
-        CONF_SWITCH: DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+        CONF_SWITCH: SWITCH_BASE_RENDER_SCHEMA.extend(
             {
                 cv.GenerateID(CONF_ID): cv.declare_id(SwitchMenuRender),
-                cv.Optional(CONF_ON_TEXT, default="On"): cv.string_strict,
-                cv.Optional(CONF_OFF_TEXT, default="Off"): cv.string_strict,
             }
         ),
-        CONF_SENSOR: DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+        CONF_SENSOR: SENSOR_BASE_RENDER_SCHEMA.extend(
             {
                 cv.GenerateID(CONF_ID): cv.declare_id(SensorMenuRender),
-                cv.Optional(CONF_NO_DATA_TEXT, default="Nan"): cv.string_strict,
-                cv.Optional(CONF_ACCURACY, default=-1): cv.int_,
             }
         ),
-        CONF_BINARY_SENSOR: DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+        CONF_BINARY_SENSOR: BINARY_SENSOR_BASE_RENDER_SCHEMA.extend(
             {
                 cv.GenerateID(CONF_ID): cv.declare_id(BinarySensorMenuRender),
-                cv.Optional(CONF_ON_TEXT, default="On"): cv.string_strict,
-                cv.Optional(CONF_OFF_TEXT, default="Off"): cv.string_strict,
-                cv.Optional(CONF_NO_DATA_TEXT, default="Nan"): cv.string_strict,
             }
         ),
         CONF_CUSTOM: DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(


### PR DESCRIPTION
# What does this implement/fix?

All menu items can have own items. Switches needs submenu

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
