### PR TITLE
Add support for lan867x Microchip 10BASE-T1S Single Pair

### DIFF
--- a/esphome/components/ethernet/__init__.py
+++ b/esphome/components/ethernet/__init__.py
@@ -2,7 +2,11 @@ import logging
 
 from esphome import pins
 import esphome.codegen as cg
-from esphome.components.esp32 import add_idf_sdkconfig_option, get_esp32_variant
+from esphome.components.esp32 import (
+    add_idf_component,
+    add_idf_sdkconfig_option,
+    get_esp32_variant,
+)
 from esphome.components.esp32.const import (
     VARIANT_ESP32C3,
     VARIANT_ESP32S2,
@@ -70,6 +74,7 @@ ETHERNET_TYPES = {
     "W5500": EthernetType.ETHERNET_TYPE_W5500,
     "OPENETH": EthernetType.ETHERNET_TYPE_OPENETH,
     "DM9051": EthernetType.ETHERNET_TYPE_DM9051,
+    "LAN867X": EthernetType.ETHERNET_TYPE_LAN867X,
 }
 
 SPI_ETHERNET_TYPES = ["W5500", "DM9051"]
@@ -128,6 +133,9 @@ def _validate(config):
         else:
             use_address = CORE.name + config[CONF_DOMAIN]
         config[CONF_USE_ADDRESS] = use_address
+    if config.get(CONF_TYPE) == "LAN867X":
+        validator = cv.require_framework_version(esp_idf=cv.Version(5, 3, 0))
+        validator(config)
     if config[CONF_TYPE] in SPI_ETHERNET_TYPES:
         if _is_framework_spi_polling_mode_supported():
             if CONF_POLLING_INTERVAL in config and CONF_INTERRUPT_PIN in config:
@@ -241,6 +249,7 @@ CONFIG_SCHEMA = cv.All(
             "W5500": SPI_SCHEMA,
             "OPENETH": BASE_SCHEMA,
             "DM9051": SPI_SCHEMA,
+            "LAN867X": RMII_SCHEMA,
         },
         upper=True,
     ),
@@ -294,6 +303,17 @@ def phy_register(address: int, value: int, page: int):
 async def to_code(config):
     var = cg.new_Pvariable(config[CONF_ID])
     await cg.register_component(var, config)
+
+    if config[CONF_TYPE] == "LAN867X":
+        add_idf_component(
+            name="esp-eth-drivers",
+            repo="https://github.com/espressif/esp-eth-drivers.git",
+            ref="master",
+            path="lan867x",
+        )
+        add_idf_sdkconfig_option("CONFIG_GPIO_CTRL_FUNC_IN_IRAM", True)
+        add_idf_sdkconfig_option("CONFIG_ETHERNET_INTERNAL_SUPPORT", True)
+        add_idf_sdkconfig_option("CONFIG_ETHERNET_PHY_LAN867X", True)
 
     if config[CONF_TYPE] in SPI_ETHERNET_TYPES:
         cg.add(var.set_clk_pin(config[CONF_CLK_PIN]))

--- a/esphome/components/ethernet/ethernet_component.cpp
+++ b/esphome/components/ethernet/ethernet_component.cpp
@@ -206,6 +206,12 @@ void EthernetComponent::setup() {
       this->phy_ = esp_eth_phy_new_ksz80xx(&phy_config);
       break;
     }
+#if CONFIG_ETHERNET_PHY_LAN867X
+    case ETHERNET_TYPE_LAN867X: {
+      this->phy_ = esp_eth_phy_new_lan867x(&phy_config);
+      break;
+    }
+#endif
 #endif
 #ifdef USE_ETHERNET_SPI
 #if CONFIG_ETH_SPI_ETHERNET_W5500
@@ -356,6 +362,10 @@ void EthernetComponent::dump_config() {
 
     case ETHERNET_TYPE_DM9051:
       eth_type = "DM9051";
+      break;
+
+    case ETHERNET_TYPE_LAN867X:
+      eth_type = "LAN867X";
       break;
 
     default:

--- a/esphome/components/ethernet/ethernet_component.h
+++ b/esphome/components/ethernet/ethernet_component.h
@@ -12,6 +12,10 @@
 #include "esp_netif.h"
 #include "esp_mac.h"
 
+#if CONFIG_ETHERNET_PHY_LAN867X
+#include "esp_eth_phy_lan867x.h"
+#endif
+
 namespace esphome {
 namespace ethernet {
 
@@ -27,6 +31,7 @@ enum EthernetType : uint8_t {
   ETHERNET_TYPE_W5500,
   ETHERNET_TYPE_OPENETH,
   ETHERNET_TYPE_DM9051,
+  ETHERNET_TYPE_LAN867X,
 };
 
 struct ManualIP {


### PR DESCRIPTION
Add support for lan867x Microchip 10BASE-T1S Single Pair Ethernet PHY via espressif esp-eth-drivers component for IDF>=5.3.0

# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
