### PR TITLE
[JXD-328] Dynamic menu generating

### DIFF
--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -30,7 +30,7 @@ from esphome.const import (
 )
 
 CONF_GENERATE_LAMBDA = "generate_lambda"
-CONF_ON_ENTER_GENERATE = "on_enter_generate"
+CONF_GENERATE_ON_ENTER = "generate_on_enter"
 
 CODEOWNERS = ["@numo68"]
 
@@ -234,7 +234,7 @@ MENU_ITEM_SCHEMA = cv.typed_schema(
                     cv.Optional(CONF_ITEMS): cv.All(
                         cv.ensure_list(menu_item_schema), cv.Length(min=1)
                     ),
-                    cv.Optional(CONF_ON_ENTER_GENERATE): cv.boolean,
+                    cv.Optional(CONF_GENERATE_ON_ENTER): cv.boolean,
                     cv.Optional(CONF_GENERATE_LAMBDA): cv.lambda_,
                 }
             ).extend(gp.LIST_OF_GROUPS_SCHEMA),
@@ -468,8 +468,8 @@ async def menu_item_to_code(menu, config, parent):
             for group in groups:
                 group_var = await cg.get_variable(group)
                 cg.add(item.add_group(group_var))
-        if config.get(CONF_ON_ENTER_GENERATE):
-            cg.add(item.set_generate_on_enter(config[CONF_ON_ENTER_GENERATE]))
+        if config.get(CONF_GENERATE_ON_ENTER):
+            cg.add(item.set_generate_on_enter(config[CONF_GENERATE_ON_ENTER]))
         if lambda_config := config.get(CONF_GENERATE_LAMBDA):
             lambda_ = await cg.process_lambda(
                 lambda_config,

--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -29,6 +29,9 @@ from esphome.const import (
     CONF_VALUE,
 )
 
+CONF_GENERATE_LAMBDA = "generate_lambda"
+CONF_ON_ENTER_GENERATE = "on_enter_generate"
+
 CODEOWNERS = ["@numo68"]
 
 AUTO_LOAD = ["display_menu_render_base", "groups"]
@@ -147,7 +150,11 @@ def validate_format(format):
 
 
 def validate_items_groups_in_menu(config):
-    if CONF_ITEMS not in config and CONF_GROUPS not in config:
+    if (
+        CONF_ITEMS not in config
+        and CONF_GROUPS not in config
+        and CONF_GENERATE_LAMBDA not in config
+    ):
         raise cv.Invalid(
             "Menu item should have at least one of the keys: groups, items"
         )
@@ -227,6 +234,8 @@ MENU_ITEM_SCHEMA = cv.typed_schema(
                     cv.Optional(CONF_ITEMS): cv.All(
                         cv.ensure_list(menu_item_schema), cv.Length(min=1)
                     ),
+                    cv.Optional(CONF_ON_ENTER_GENERATE): cv.boolean,
+                    cv.Optional(CONF_GENERATE_LAMBDA): cv.lambda_,
                 }
             ).extend(gp.LIST_OF_GROUPS_SCHEMA),
             validate_items_groups_in_menu,
@@ -459,6 +468,18 @@ async def menu_item_to_code(menu, config, parent):
             for group in groups:
                 group_var = await cg.get_variable(group)
                 cg.add(item.add_group(group_var))
+        if config.get(CONF_ON_ENTER_GENERATE):
+            cg.add(item.set_generate_on_enter(config[CONF_ON_ENTER_GENERATE]))
+        if lambda_config := config.get(CONF_GENERATE_LAMBDA):
+            lambda_ = await cg.process_lambda(
+                lambda_config,
+                [
+                    (MenuItemMenuPtr, "menu"),
+                ],
+                return_type=cg.size_t,
+            )
+            cg.add(item.set_generate_lambda(lambda_))
+
     for conf in config.get(CONF_ON_ENTER, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], item)
         await automation.build_automation(trigger, [(MenuItemConstPtr, "it")], conf)

--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -156,7 +156,7 @@ def validate_items_groups_in_menu(config):
         and CONF_GENERATE_LAMBDA not in config
     ):
         raise cv.Invalid(
-            "Menu item should have at least one of the keys: groups, items"
+            "Menu item should have at least one of the keys: groups, items, generate_lambda"
         )
     return config
 

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -11,7 +11,7 @@ void DisplayMenuComponent::recurse_menu_items_(MenuItemMenu *parent_menu) {
   // Find menu items with groups and generate_items
   for (size_t i = 0; i < parent_menu->items_size(); i++) {
     MenuItem *item = parent_menu->get_item(i);
-    if (item->get_type() == MENU_ITEM_MENU && !item->is_generate_on_enter()) {
+    if (item->get_type() == MENU_ITEM_MENU && !static_cast<MenuItemMenu *>(item)->is_generate_on_enter()) {
       MenuItemMenu *menu = static_cast<MenuItemMenu *>(item);
       recurse_menu_items_(menu);
       generate_to_menu_items_(menu);
@@ -410,8 +410,9 @@ bool DisplayMenuComponent::enter_menu_() {
   this->displayed_item_->on_leave();
   this->displayed_item_ = this->get_selected_item_();
   auto *item = this->displayed_item_;
-  if (item->get_type() == MENU_ITEM_MENU && item->is_generate_on_enter())
+  if (item->get_type() == MENU_ITEM_MENU && static_cast<MenuItemMenu *>(item)->is_generate_on_enter()) {
     this->generate_to_menu_items_(static_cast<MenuItemMenu *>(item));
+  }
   this->selection_stack_.emplace_front(this->top_index_, this->cursor_index_);
   this->cursor_index_ = this->top_index_ = 0;
   this->displayed_item_->on_enter();
@@ -424,8 +425,9 @@ bool DisplayMenuComponent::leave_menu_() {
 
   if (this->displayed_item_->get_parent() != nullptr) {
     this->displayed_item_->on_leave();
-    if (this->displayed_item_->is_generate_on_enter()) {
-      this->displayed_item_->clear_items();
+    auto *item = this->displayed_item_;
+    if (item->get_type() == MENU_ITEM_MENU && static_cast<MenuItemMenu *>(item)->is_generate_on_enter()) {
+      static_cast<MenuItemMenu *>(item)->clear_items();
     }
     this->displayed_item_ = this->displayed_item_->get_parent();
     this->top_index_ = this->selection_stack_.front().first;

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -11,7 +11,7 @@ void DisplayMenuComponent::recurse_menu_items_(MenuItemMenu *parent_menu) {
   // Find menu items with groups and generate_items
   for (size_t i = 0; i < parent_menu->items_size(); i++) {
     MenuItem *item = parent_menu->get_item(i);
-    if (item->get_type() == MENU_ITEM_MENU) {
+    if (item->get_type() == MENU_ITEM_MENU && !item->is_generate_on_enter()) {
       MenuItemMenu *menu = static_cast<MenuItemMenu *>(item);
       recurse_menu_items_(menu);
       generate_to_menu_items_(menu);
@@ -20,6 +20,9 @@ void DisplayMenuComponent::recurse_menu_items_(MenuItemMenu *parent_menu) {
 }
 
 void DisplayMenuComponent::generate_to_menu_items_(MenuItemMenu *menu) {
+  if (menu->is_generated())
+    return;
+
   size_t num_items = menu->items_size();
 #ifdef USE_GROUPS
   for (groups::Group *group : menu->groups()) {
@@ -32,6 +35,9 @@ void DisplayMenuComponent::generate_to_menu_items_(MenuItemMenu *menu) {
     back_item->set_text("No items in menu. Back");
     menu->add_item(back_item);
   }
+
+  // was generated
+  menu->set_was_generated(true);
 }
 
 size_t DisplayMenuComponent::process_group_(MenuItemMenu *menu, groups::Group *group) {
@@ -399,6 +405,8 @@ bool DisplayMenuComponent::cursor_down_() {
 bool DisplayMenuComponent::enter_menu_() {
   this->displayed_item_->on_leave();
   this->displayed_item_ = this->get_selected_item_();
+  if (item->is_generate_on_enter())
+    this->generate_to_menu_items_(this->displayed_item_);
   this->selection_stack_.emplace_front(this->top_index_, this->cursor_index_);
   this->cursor_index_ = this->top_index_ = 0;
   this->displayed_item_->on_enter();
@@ -411,6 +419,9 @@ bool DisplayMenuComponent::leave_menu_() {
 
   if (this->displayed_item_->get_parent() != nullptr) {
     this->displayed_item_->on_leave();
+    if (this->displayed_item_->is_generate_on_enter()) {
+      this->displayed_item_->clear_items();
+    }
     this->displayed_item_ = this->displayed_item_->get_parent();
     this->top_index_ = this->selection_stack_.front().first;
     this->cursor_index_ = this->selection_stack_.front().second;

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -30,6 +30,10 @@ void DisplayMenuComponent::generate_to_menu_items_(MenuItemMenu *menu) {
   }
 #endif
 
+  // TODO call lambda which create other items
+  //
+  num_items += menu->generate();
+
   if (num_items == 0) {
     display_menu_base::MenuItem *back_item = new display_menu_base::MenuItem(display_menu_base::MENU_ITEM_BACK);
     back_item->set_text("No items in menu. Back");
@@ -405,8 +409,9 @@ bool DisplayMenuComponent::cursor_down_() {
 bool DisplayMenuComponent::enter_menu_() {
   this->displayed_item_->on_leave();
   this->displayed_item_ = this->get_selected_item_();
-  if (item->is_generate_on_enter())
-    this->generate_to_menu_items_(this->displayed_item_);
+  auto *item = this->displayed_item_;
+  if (item->get_type() == MENU_ITEM_MENU && item->is_generate_on_enter())
+    this->generate_to_menu_items_(static_cast<MenuItemMenu *>(item));
   this->selection_stack_.emplace_front(this->top_index_, this->cursor_index_);
   this->cursor_index_ = this->top_index_ = 0;
   this->displayed_item_->on_enter();

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -30,8 +30,6 @@ void DisplayMenuComponent::generate_to_menu_items_(MenuItemMenu *menu) {
   }
 #endif
 
-  // TODO call lambda which create other items
-  //
   num_items += menu->generate();
 
   if (num_items == 0) {
@@ -40,7 +38,6 @@ void DisplayMenuComponent::generate_to_menu_items_(MenuItemMenu *menu) {
     menu->add_item(back_item);
   }
 
-  // was generated
   menu->set_was_generated(true);
 }
 

--- a/esphome/components/display_menu_base/menu_item.h
+++ b/esphome/components/display_menu_base/menu_item.h
@@ -111,7 +111,7 @@ class MenuItemMenu : public MenuItemValueBase {
  public:
   using generate_lambda_t = std::function<size_t(MenuItemMenu *menu)>;
   explicit MenuItemMenu() : MenuItemValueBase(MENU_ITEM_MENU) {}
-  ~MenuItemMenu() { clear_items(); }
+  ~MenuItemMenu() override { clear_items(); }
   void add_generated_items(MenuItem *item) {
     item->set_parent(this);
     this->items_.push_back(item);

--- a/esphome/components/display_menu_base/menu_item.h
+++ b/esphome/components/display_menu_base/menu_item.h
@@ -50,8 +50,8 @@ class MenuItem {
  public:
   explicit MenuItem(MenuItemType t) : item_type_(t) {}
   virtual ~MenuItem() { clear_items(); }
-  void set_parent(MenuItemMenu *parent) { this->parent_ = parent; }
-  MenuItemMenu *get_parent() { return this->parent_; }
+  void set_parent(MenuItem *parent) { this->parent_ = parent; }
+  MenuItem *get_parent() { return this->parent_; }
   MenuItemType get_type() const { return this->item_type_; }
   template<typename V> void set_text(V val) { this->text_ = val; }
   void add_on_enter_callback(std::function<void()> &&cb) { this->on_enter_callbacks_.add(std::move(cb)); }
@@ -78,7 +78,7 @@ class MenuItem {
   bool is_generated() { return this->generated_; }
   void set_was_generated(bool val) { this->generated_ = val; }
 
-  bool is_generate_on_enter() { return this->generate_on_enter; }
+  bool is_generate_on_enter() { return this->generate_on_enter_; }
   void set_generate_on_enter(bool val) { this->generate_on_enter_ = val; }
 
   void clear_items() {
@@ -86,7 +86,7 @@ class MenuItem {
       delete item;
     }
     this->items_.clear();
-    this->need_generate_ = true;
+    this->generated_ = false;
   }
 
   virtual bool select_next() { return false; }
@@ -125,11 +125,19 @@ class MenuItemValueBase : public MenuItem {
 
 class MenuItemMenu : public MenuItemValueBase {
  public:
+  using generate_lambda_t = std::function<size_t(MenuItemMenu *menu)>;
   explicit MenuItemMenu() : MenuItemValueBase(MENU_ITEM_MENU) {}
   void add_generated_items(MenuItem *item) {
     item->set_parent(this);
     this->items_.push_back(item);
   }
+  size_t generate() {
+    if (lambda_)
+      return lambda_(this);
+    return 0;
+  }
+  void set_generate_lambda(generate_lambda_t &&lambda) { this->lambda_ = lambda; }
+  generate_lambda_t lambda_;
 #ifdef USE_GROUPS
   void add_group(groups::Group *group) { this->groups_.push_back(group); }
   const std::vector<groups::Group *> &groups() { return groups_; }

--- a/esphome/components/display_menu_base/menu_item.h
+++ b/esphome/components/display_menu_base/menu_item.h
@@ -49,7 +49,7 @@ using value_getter_t = std::function<std::string(const MenuItem *)>;
 class MenuItem {
  public:
   explicit MenuItem(MenuItemType t) : item_type_(t) {}
-  virtual ~MenuItem() { clear_items(); }
+  virtual ~MenuItem() {}
   void set_parent(MenuItem *parent) { this->parent_ = parent; }
   MenuItem *get_parent() { return this->parent_; }
   MenuItemType get_type() const { return this->item_type_; }
@@ -75,20 +75,6 @@ class MenuItem {
   size_t items_size() const { return this->items_.size(); }
   MenuItem *get_item(size_t i) const { return this->items_[i]; }
 
-  bool is_generated() { return this->generated_; }
-  void set_was_generated(bool val) { this->generated_ = val; }
-
-  bool is_generate_on_enter() { return this->generate_on_enter_; }
-  void set_generate_on_enter(bool val) { this->generate_on_enter_ = val; }
-
-  void clear_items() {
-    for (auto *item : this->items_) {
-      delete item;
-    }
-    this->items_.clear();
-    this->generated_ = false;
-  }
-
   virtual bool select_next() { return false; }
   virtual bool select_prev() { return false; }
 
@@ -108,8 +94,6 @@ class MenuItem {
 
   std::vector<MenuItem *> items_;
   bool has_internal_items_{false};
-  bool generated_{false};
-  bool generate_on_enter_{false};
 };
 
 class MenuItemValueBase : public MenuItem {
@@ -127,6 +111,7 @@ class MenuItemMenu : public MenuItemValueBase {
  public:
   using generate_lambda_t = std::function<size_t(MenuItemMenu *menu)>;
   explicit MenuItemMenu() : MenuItemValueBase(MENU_ITEM_MENU) {}
+  ~MenuItemMenu() { clear_items(); }
   void add_generated_items(MenuItem *item) {
     item->set_parent(this);
     this->items_.push_back(item);
@@ -137,7 +122,21 @@ class MenuItemMenu : public MenuItemValueBase {
     return 0;
   }
   void set_generate_lambda(generate_lambda_t &&lambda) { this->lambda_ = lambda; }
-  generate_lambda_t lambda_;
+
+  bool is_generated() { return this->generated_; }
+  void set_was_generated(bool val) { this->generated_ = val; }
+
+  bool is_generate_on_enter() { return this->generate_on_enter_; }
+  void set_generate_on_enter(bool val) { this->generate_on_enter_ = val; }
+
+  void clear_items() {
+    for (auto *item : this->items_) {
+      delete item;
+    }
+    this->items_.clear();
+    this->generated_ = false;
+  }
+
 #ifdef USE_GROUPS
   void add_group(groups::Group *group) { this->groups_.push_back(group); }
   const std::vector<groups::Group *> &groups() { return groups_; }
@@ -146,6 +145,9 @@ class MenuItemMenu : public MenuItemValueBase {
 #ifdef USE_GROUPS
   std::vector<groups::Group *> groups_;
 #endif
+  generate_lambda_t lambda_;
+  bool generated_{false};
+  bool generate_on_enter_{false};
 };
 
 class MenuItemEditable : public MenuItemValueBase {

--- a/esphome/components/display_menu_base/menu_item.h
+++ b/esphome/components/display_menu_base/menu_item.h
@@ -49,8 +49,9 @@ using value_getter_t = std::function<std::string(const MenuItem *)>;
 class MenuItem {
  public:
   explicit MenuItem(MenuItemType t) : item_type_(t) {}
-  void set_parent(MenuItem *parent) { this->parent_ = parent; }
-  MenuItem *get_parent() { return this->parent_; }
+  virtual ~MenuItem() {}
+  void set_parent(MenuItemMenu *parent) { this->parent_ = parent; }
+  MenuItemMenu *get_parent() { return this->parent_; }
   MenuItemType get_type() const { return this->item_type_; }
   template<typename V> void set_text(V val) { this->text_ = val; }
   void add_on_enter_callback(std::function<void()> &&cb) { this->on_enter_callbacks_.add(std::move(cb)); }
@@ -74,6 +75,17 @@ class MenuItem {
   size_t items_size() const { return this->items_.size(); }
   MenuItem *get_item(size_t i) const { return this->items_[i]; }
 
+  bool is_generated() { return this->generated_; }
+  void set_was_generated(bool val) { this->generated_ = val; }
+
+  bool is_generate_on_enter() { return this->generate_on_enter; }
+  void set_generate_on_enter(bool val) { this->generate_on_enter_ = val; }
+
+  void clear_items() {
+    this->items_.clear();
+    this->need_generate_ = true;
+  }
+
   virtual bool select_next() { return false; }
   virtual bool select_prev() { return false; }
 
@@ -93,6 +105,8 @@ class MenuItem {
 
   std::vector<MenuItem *> items_;
   bool has_internal_items_{false};
+  bool generated_{false};
+  bool generate_on_enter_{false};
 };
 
 class MenuItemValueBase : public MenuItem {

--- a/esphome/components/display_menu_base/menu_item.h
+++ b/esphome/components/display_menu_base/menu_item.h
@@ -49,7 +49,7 @@ using value_getter_t = std::function<std::string(const MenuItem *)>;
 class MenuItem {
  public:
   explicit MenuItem(MenuItemType t) : item_type_(t) {}
-  virtual ~MenuItem() {}
+  virtual ~MenuItem() { clear_items(); }
   void set_parent(MenuItemMenu *parent) { this->parent_ = parent; }
   MenuItemMenu *get_parent() { return this->parent_; }
   MenuItemType get_type() const { return this->item_type_; }
@@ -82,6 +82,9 @@ class MenuItem {
   void set_generate_on_enter(bool val) { this->generate_on_enter_ = val; }
 
   void clear_items() {
+    for (auto *item : this->items_) {
+      delete item;
+    }
     this->items_.clear();
     this->need_generate_ = true;
   }


### PR DESCRIPTION
# What does this implement/fix?

Изначально PR создавался для возможности вывести актуальный список wifi сети при входе в этот пункт меню. Теперь же можно использовать его для отображения актуальных динамических списков entity

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [x] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml
 - type: menu
              text: "WiFi list"
              generate_on_enter: true
              generate_lambda: |-
                if (!id(wifi_switch).state) {
                  display_menu_base::MenuItem *item = new display_menu_base::MenuItem(display_menu_base::MENU_ITEM_LABEL);
                  item->set_text("WiFi is disabled");
                  menu->add_item(item);
                  return 1;
                }
    - type: menu
      text: 'Relays'
      generate_on_enter: true
      groups:
        - rele_group_id
    
```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).
