### PR TITLE
docker/generate_tags.py: add jh release suffix

### DIFF
--- a/docker/generate_tags.py
+++ b/docker/generate_tags.py
@@ -37,7 +37,7 @@ def main():
     args = parser.parse_args()
 
     # detect channel from tag
-    match = re.match(r"^(\d+\.\d+)(?:\.\d+)(?:(b\d+)|(-dev\d+))?$", args.tag)
+    match = re.match(r"^(\d+\.\d+)\.\d+(?:(b\d+)|(-dev\d+)|(jh\d*))?$",args.tag)
     major_minor_version = None
     if match is None:  # eg 2023.12.0-dev20231109-testbranch
         channel = None  # Ran with custom tag for a branch etc

--- a/docker/generate_tags.py
+++ b/docker/generate_tags.py
@@ -37,7 +37,7 @@ def main():
     args = parser.parse_args()
 
     # detect channel from tag
-    match = re.match(r"^(\d+\.\d+)\.\d+(?:(b\d+)|(-dev\d+)|(jh\d*))?$",args.tag)
+    match = re.match(r"^(\d+\.\d+)\.\d+(?:(b\d+)|(-dev\d+)|(jh\d*))?$", args.tag)
     major_minor_version = None
     if match is None:  # eg 2023.12.0-dev20231109-testbranch
         channel = None  # Ran with custom tag for a branch etc


### PR DESCRIPTION
update docker/generate_tags.py for JetHome release tags

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for JetHome release suffixes in Docker tag parsing.
> 
> - Updates regex in `docker/generate_tags.py` to accept tags like `2023.12.0jh1` (pattern now allows optional `jh\d*`), while preserving existing `beta` and `dev` detection
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95342d870393cb663ef93c5570a4e1720150864c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->