### PR TITLE
Fix sntp time problem

### DIFF
--- a/esphome/components/sntp/sntp_component.cpp
+++ b/esphome/components/sntp/sntp_component.cpp
@@ -14,9 +14,14 @@ namespace sntp {
 
 static const char *const TAG = "sntp";
 
+#if defined(USE_ESP32)
+SNTPComponent *SNTPComponent::instance = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
+#endif
+
 void SNTPComponent::setup() {
   ESP_LOGCONFIG(TAG, "Running setup");
 #if defined(USE_ESP32)
+  SNTPComponent::instance = this;
   if (esp_sntp_enabled()) {
     esp_sntp_stop();
   }
@@ -26,6 +31,11 @@ void SNTPComponent::setup() {
     esp_sntp_setservername(i++, server.c_str());
   }
   esp_sntp_set_sync_interval(this->get_update_interval());
+  esp_sntp_set_time_sync_notification_cb([](struct timeval *tv) {
+    if (SNTPComponent::instance != nullptr) {
+      SNTPComponent::instance->defer([]() { SNTPComponent::instance->time_synced(); });
+    }
+  });
   esp_sntp_init();
 #else
   sntp_stop();
@@ -35,6 +45,14 @@ void SNTPComponent::setup() {
   for (auto &server : this->servers_) {
     sntp_setservername(i++, server.c_str());
   }
+
+#if defined(USE_ESP8266)
+  settimeofday_cb([this](bool from_sntp) {
+    if (from_sntp)
+      this->time_synced();
+  });
+#endif
+
   sntp_init();
 #endif
 }
@@ -47,7 +65,8 @@ void SNTPComponent::dump_config() {
 }
 void SNTPComponent::update() {
 #if !defined(USE_ESP32)
-  // force resync
+  // Some platforms currently cannot set the sync interval at runtime so we need
+  // to do the re-sync by hand for now.
   if (sntp_enabled()) {
     sntp_stop();
     this->has_time_ = false;
@@ -56,23 +75,31 @@ void SNTPComponent::update() {
 #endif
 }
 void SNTPComponent::loop() {
+// The loop is used to infer whether we have valid time on platforms where we
+// cannot tell whether SNTP has succeeded.
+// One limitation of this approach is that we cannot tell if it was the SNTP
+// component that set the time.
+// ESP-IDF and ESP8266 use callbacks from the SNTP task to trigger the
+// `on_time_sync` trigger on successful sync events.
+#if defined(USE_ESP32) || defined(USE_ESP8266)
+  this->disable_loop();
+#endif
+
   if (this->has_time_)
     return;
 
+  this->time_synced();
+}
+
+void SNTPComponent::time_synced() {
   auto time = this->now();
-  if (!time.is_valid())
+  this->has_time_ = time.is_valid();
+  if (!this->has_time_)
     return;
 
   ESP_LOGD(TAG, "Synchronized time: %04d-%02d-%02d %02d:%02d:%02d", time.year, time.month, time.day_of_month, time.hour,
            time.minute, time.second);
   this->time_sync_callback_.call();
-  this->has_time_ = true;
-
-#ifdef USE_ESP_IDF
-  // On ESP-IDF, time sync is permanent and update() doesn't force resync
-  // Time is now synchronized, no need to check anymore
-  this->disable_loop();
-#endif
 }
 
 }  // namespace sntp

--- a/esphome/components/sntp/sntp_component.h
+++ b/esphome/components/sntp/sntp_component.h
@@ -26,9 +26,16 @@ class SNTPComponent : public time::RealTimeClock {
   void update() override;
   void loop() override;
 
+  void time_synced();
+
  protected:
   std::vector<std::string> servers_;
   bool has_time_{false};
+
+#if defined(USE_ESP32)
+ private:
+  static SNTPComponent *instance;
+#endif
 };
 
 }  // namespace sntp


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add platform-specific SNTP time-sync callbacks (ESP32/ESP8266), centralize sync handling in `time_synced()`, and disable polling loop where callbacks exist.
> 
> - **SNTP time sync handling**:
>   - **ESP32**: Register `esp_sntp_set_time_sync_notification_cb` to trigger `time_synced()` via a static `SNTPComponent::instance`; initialize/stop SNTP as needed and set sync interval.
>   - **ESP8266**: Use `settimeofday_cb` to call `time_synced()` on SNTP updates.
>   - **Other platforms**: Keep manual re-sync in `update()` where runtime sync interval isn’t supported.
> - **Control flow**:
>   - Add `time_synced()` method; set `has_time_` based on `now().is_valid()` and invoke `time_sync_callback_`.
>   - Disable `loop()` on ESP32/ESP8266; otherwise use it to infer valid time when callbacks aren’t available.
> - **API/structure**:
>   - Declare `time_synced()` in header; add static `SNTPComponent *instance` (ESP32-only).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba77e697e9595d04a3acf4df0dcd18a1c84df59b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->