### PR TITLE
[esp32-preferences] Methods improvement from 2025.10.5

### DIFF
--- a/esphome/components/esp32/esp32_base_preferences.cpp
+++ b/esphome/components/esp32/esp32_base_preferences.cpp
@@ -42,7 +42,7 @@ bool ESP32BasePreferences::sync() {
   if (this->pending_save_.empty())
     return true;
 
-  ESP_LOGV(TAG, "Saving %d items...", this->pending_save_.size());
+  ESP_LOGV(TAG, "Saving %zu items...", this->pending_save_.size());
   // goal try write all pending saves even if one fails
   int cached = 0, written = 0, failed = 0;
   esp_err_t last_err = ESP_OK;
@@ -54,20 +54,19 @@ bool ESP32BasePreferences::sync() {
     ESP_LOGVV(TAG, "Checking if NVS data %s has changed", save.key.c_str());
     esp_err_t err = ESP_OK;
     bool changed = false;
-    if (save.data.empty()) {
+    if (save.data == nullptr || save.len == 0) {
       err = nvs_erase_key(this->nvs_handle_, save.key.c_str());
       ESP_LOGV(TAG, "remove: key: %s", save.key.c_str());
       changed = true;
     } else if (is_changed(save)) {
-      err = nvs_set_blob(this->nvs_handle_, save.key.c_str(), save.data.data(), save.data.size());
-      ESP_LOGV(TAG, "sync: key: %s, len: %d", save.key.c_str(), save.data.size());
+      err = nvs_set_blob(this->nvs_handle_, save.key.c_str(), save.data.get(), save.len);
+      ESP_LOGV(TAG, "sync: key: %s, len: %zu", save.key.c_str(), save.len);
       changed = true;
     }
 
     if (changed) {
       if (err != 0) {
-        ESP_LOGV(TAG, "nvs_set_blob('%s', len=%u) failed: %s", save.key.c_str(), save.data.size(),
-                 esp_err_to_name(err));
+        ESP_LOGV(TAG, "nvs_set_blob('%s', len=%zu) failed: %s", save.key.c_str(), save.len, esp_err_to_name(err));
         failed++;
         last_err = err;
         last_key = save.key;
@@ -75,7 +74,7 @@ bool ESP32BasePreferences::sync() {
       }
       written++;
     } else {
-      ESP_LOGV(TAG, "NVS data not changed skipping %s  len=%u", save.key.c_str(), save.data.size());
+      ESP_LOGV(TAG, "NVS data not changed skipping %s  len=%zu", save.key.c_str(), save.len);
       cached++;
     }
     this->pending_save_.erase(this->pending_save_.begin() + i);
@@ -106,7 +105,7 @@ bool ESP32BasePreferences::is_changed(const NVSData &to_save) {
     return true;
   }
   // Check size first before allocating memory
-  if (actual_len != to_save.data.size()) {
+  if (actual_len != to_save.len) {
     return true;
   }
   auto stored_data = std::make_unique<uint8_t[]>(actual_len);
@@ -115,7 +114,7 @@ bool ESP32BasePreferences::is_changed(const NVSData &to_save) {
     ESP_LOGV(TAG, "nvs_get_blob('%s') failed: %s", to_save.key.c_str(), esp_err_to_name(err));
     return true;
   }
-  return memcmp(to_save.data.data(), stored_data.get(), to_save.data.size()) != 0;
+  return memcmp(to_save.data.get(), stored_data.get(), to_save.len) != 0;
 }
 
 void ESP32BasePreferences::reset() {

--- a/esphome/components/esp32/esp32_preference_backend.cpp
+++ b/esphome/components/esp32/esp32_preference_backend.cpp
@@ -11,26 +11,26 @@ bool ESP32PreferenceBackend::save(const uint8_t *data, size_t len) {
   // try find in pending saves and update that
   for (auto &obj : pending_save) {
     if (obj.key == key) {
-      obj.data.assign(data, data + len);
+      obj.set_data(data, len);
       return true;
     }
   }
   NVSData save{};
   save.key = key;
-  save.data.assign(data, data + len);
-  pending_save.emplace_back(save);
-  ESP_LOGVV(TAG, "pending_save: key: %s, len: %d", key.c_str(), len);
+  save.set_data(data, len);
+  pending_save.emplace_back(std::move(save));
+  ESP_LOGVV(TAG, "pending_save: key: %s, len: %zu", key.c_str(), len);
   return true;
 }
 bool ESP32PreferenceBackend::load(uint8_t *data, size_t len) {
   // try find in pending saves and load from that
   for (auto &obj : pending_save) {
     if (obj.key == key) {
-      if (obj.data.size() != len) {
+      if (obj.len != len) {
         // size mismatch
         return false;
       }
-      memcpy(data, obj.data.data(), len);
+      memcpy(data, obj.data.get(), len);
       return true;
     }
   }
@@ -41,7 +41,7 @@ bool ESP32PreferenceBackend::load(uint8_t *data, size_t len) {
     return false;
   }
   if (actual_len != len) {
-    ESP_LOGVV(TAG, "NVS length does not match (%u!=%u)", actual_len, len);
+    ESP_LOGVV(TAG, "NVS length does not match (%zu!=%zu)", actual_len, len);
     return false;
   }
   err = nvs_get_blob(nvs_handle, key.c_str(), data, &len);
@@ -49,7 +49,7 @@ bool ESP32PreferenceBackend::load(uint8_t *data, size_t len) {
     ESP_LOGV(TAG, "nvs_get_blob('%s') failed: %s", key.c_str(), esp_err_to_name(err));
     return false;
   } else {
-    ESP_LOGVV(TAG, "nvs_get_blob: key: %s, len: %d", key.c_str(), len);
+    ESP_LOGVV(TAG, "nvs_get_blob: key: %s, len: %zu", key.c_str(), len);
   }
   return true;
 }
@@ -63,7 +63,9 @@ bool ESP32PreferenceBackend::remove() {
   }
   NVSData save{};
   save.key = key;
-  pending_save.emplace_back(save);
+  save.data = nullptr;
+  save.len = 0;
+  pending_save.emplace_back(std::move(save));
   return true;
 }
 

--- a/esphome/components/esp32/esp32_preference_backend.h
+++ b/esphome/components/esp32/esp32_preference_backend.h
@@ -2,6 +2,8 @@
 #ifdef USE_ESP32
 
 #include <string>
+#include <memory>
+#include <cstring>
 #include "esphome/core/helpers.h"
 #include "esphome/core/log.h"
 #include "esphome/core/preferences.h"
@@ -11,7 +13,14 @@ namespace esp32 {
 
 struct NVSData {
   std::string key;
-  std::vector<uint8_t> data;
+  std::unique_ptr<uint8_t[]> data;
+  size_t len;
+
+  void set_data(const uint8_t *src, size_t size) {
+    data = std::make_unique<uint8_t[]>(size);
+    memcpy(data.get(), src, size);
+    len = size;
+  }
 };
 
 class ESP32PreferenceBackend : public ESPPreferenceBackend {


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Migrate NVS data handling from vectors to raw buffers with explicit lengths, updating save/load/remove logic and size-aware logging.
> 
> - **ESP32 preferences**:
>   - Replace `std::vector<uint8_t>` with `std::unique_ptr<uint8_t[]>` plus `len` in `NVSData`, add `set_data()`.
>   - Update save/load/remove paths to use raw buffers (`data.get()`) and `len`; treat `data == nullptr || len == 0` as deletion.
>   - Adjust change detection to compare `len` and `memcmp(data.get(), ...)`.
>   - Use correct size format specifiers (`%zu`) across logs and NVS operations.
>   - Add necessary includes (`<memory>`, `<cstring>`) and declare `remove()` override in header.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e63c58224283ad50c0343121360b78302b4afdb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->