### PR TITLE
Jxd 303 fix fulltest problems

### DIFF
--- a/esphome/components/display_menu_base/menu_item.cpp
+++ b/esphome/components/display_menu_base/menu_item.cpp
@@ -34,7 +34,7 @@ void MenuItem::on_enter() { this->on_enter_callbacks_.call(); }
 
 void MenuItem::on_leave() { this->on_leave_callbacks_.call(); }
 
-void MenuItem::on_value_() { this->on_value_callbacks_.call(); }
+void MenuItem::on_value() { this->on_value_callbacks_.call(); }
 
 std::string MenuItemBinarySensor::get_value_text() const {
   std::string result;
@@ -68,7 +68,7 @@ bool MenuItemSelect::select_next() {
   if (this->select_var_ != nullptr) {
     this->select_var_->make_call().select_next(true).perform();
     changed = true;
-    this->on_value_();
+    this->on_value();
   }
 
   return changed;
@@ -80,7 +80,7 @@ bool MenuItemSelect::select_prev() {
   if (this->select_var_ != nullptr) {
     this->select_var_->make_call().select_previous(true).perform();
     changed = true;
-    this->on_value_();
+    this->on_value();
   }
 
   return changed;
@@ -108,7 +108,7 @@ bool MenuItemNumber::select_next() {
     this->number_var_->make_call().number_increment(false).perform();
 
     if (this->number_var_->state != last) {
-      this->on_value_();
+      this->on_value();
       changed = true;
     }
   }
@@ -124,7 +124,7 @@ bool MenuItemNumber::select_prev() {
     this->number_var_->make_call().number_decrement(false).perform();
 
     if (this->number_var_->state != last) {
-      this->on_value_();
+      this->on_value();
       changed = true;
     }
   }
@@ -171,7 +171,7 @@ bool MenuItemSwitch::toggle_switch_() {
 
   if (this->switch_var_ != nullptr) {
     this->switch_var_->toggle();
-    this->on_value_();
+    this->on_value();
     changed = true;
   }
 
@@ -183,24 +183,24 @@ std::string MenuItemValueBase::get_value_text() const {
 }
 
 bool MenuItemCommand::select_next() {
-  this->on_value_();
+  this->on_value();
   return true;
 }
 
 bool MenuItemCommand::select_prev() {
-  this->on_value_();
+  this->on_value();
   return true;
 }
 
 bool MenuItemCustom::select_next() {
   this->on_next_();
-  this->on_value_();
+  this->on_value();
   return true;
 }
 
 bool MenuItemCustom::select_prev() {
   this->on_prev_();
-  this->on_value_();
+  this->on_value();
   return true;
 }
 

--- a/esphome/components/display_menu_base/menu_item.h
+++ b/esphome/components/display_menu_base/menu_item.h
@@ -107,7 +107,7 @@ class MenuItem {
 
   void on_enter();
   void on_leave();
-  void on_value_();
+  void on_value();
 
  protected:
   MenuItemType item_type_;

--- a/esphome/components/display_menu_render_base/__init__.py
+++ b/esphome/components/display_menu_render_base/__init__.py
@@ -1,0 +1,128 @@
+import esphome.codegen as cg
+from esphome.components import display_menu_base, groups
+from esphome.components.graphical_display_menu import GraphicalDisplayMenu
+import esphome.config_validation as cv
+from esphome.const import (
+    CONF_ACCURACY,
+    CONF_BINARY_SENSOR,
+    CONF_CUSTOM,
+    CONF_GROUPS,
+    CONF_ID,
+    CONF_LAMBDA,
+    CONF_MENU_ID,
+    CONF_SENSOR,
+    CONF_SWITCH,
+    CONF_TYPE,
+)
+from esphome.core.entity_types import ENTITY_TYPES
+import esphome.cpp_types as core_types
+
+display_menu_render_ns = cg.esphome_ns.namespace("display_menu_render_base")
+BinarySensorMenuRender = display_menu_render_ns.class_("BinarySensorMenuRender")
+SensorMenuRender = display_menu_render_ns.class_("SensorMenuRender")
+SwitchMenuRender = display_menu_render_ns.class_("SwitchMenuRender")
+LambdaMenuRender = display_menu_render_ns.class_("LambdaMenuRender")
+
+
+CONF_ON_TEXT = "on_text"
+CONF_OFF_TEXT = "off_text"
+CONF_NO_DATA_TEXT = "no_data_text"
+
+DISPLAY_MENU_RENDER_BASE_SCHEMA = cv.Schema(
+    {
+        cv.GenerateID(CONF_MENU_ID): cv.use_id(GraphicalDisplayMenu),
+    }
+).extend(groups.LIST_OF_GROUPS_SCHEMA)
+
+CONF_ENT_TYPE = "ent_type"
+
+SWITCH_BASE_RENDER_SCHEMA = DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+    {
+        cv.Optional(CONF_ON_TEXT, default="On"): cv.string_strict,
+        cv.Optional(CONF_OFF_TEXT, default="Off"): cv.string_strict,
+    }
+)
+SENSOR_BASE_RENDER_SCHEMA = DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+    {
+        cv.Optional(CONF_NO_DATA_TEXT, default="Nan"): cv.string_strict,
+        cv.Optional(CONF_ACCURACY, default=-1): cv.int_,
+    }
+)
+
+BINARY_SENSOR_BASE_RENDER_SCHEMA = DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+    {
+        cv.Optional(CONF_ON_TEXT, default="On"): cv.string_strict,
+        cv.Optional(CONF_OFF_TEXT, default="Off"): cv.string_strict,
+        cv.Optional(CONF_NO_DATA_TEXT, default="Nan"): cv.string_strict,
+    }
+)
+
+BASE_RENDER_SCHEMA = cv.typed_schema(
+    {
+        CONF_SWITCH: SWITCH_BASE_RENDER_SCHEMA.extend(
+            {
+                cv.GenerateID(CONF_ID): cv.declare_id(SwitchMenuRender),
+            }
+        ),
+        CONF_SENSOR: SENSOR_BASE_RENDER_SCHEMA.extend(
+            {
+                cv.GenerateID(CONF_ID): cv.declare_id(SensorMenuRender),
+            }
+        ),
+        CONF_BINARY_SENSOR: BINARY_SENSOR_BASE_RENDER_SCHEMA.extend(
+            {
+                cv.GenerateID(CONF_ID): cv.declare_id(BinarySensorMenuRender),
+            }
+        ),
+        CONF_CUSTOM: DISPLAY_MENU_RENDER_BASE_SCHEMA.extend(
+            {
+                cv.GenerateID(CONF_ID): cv.declare_id(LambdaMenuRender),
+                cv.Required(CONF_LAMBDA): cv.lambda_,
+                cv.Optional(CONF_ENT_TYPE): cv.enum(ENTITY_TYPES),
+            }
+        ),
+    }
+)
+
+CONFIG_SCHEMA = cv.All(cv.ensure_list(BASE_RENDER_SCHEMA))
+
+
+async def render_to_code(var, config):
+    menu_var = await cg.get_variable(config[CONF_MENU_ID])
+    cg.add(menu_var.add_render(var))
+
+    if lambda_config := config.get(CONF_LAMBDA):
+        lambda_ = await cg.process_lambda(
+            lambda_config,
+            [
+                (display_menu_base.MenuItemMenuPtr, "menu"),
+                (core_types.EntityBasePtr, "entity"),
+            ],
+            return_type=cg.size_t,
+        )
+        cg.add(var.set_lambda(lambda_))
+
+    if ent_type := config.get(CONF_ENT_TYPE):
+        cg.add(var.set_type(ent_type))
+
+    if config.get(CONF_TYPE) == CONF_SWITCH:
+        cg.add(var.set_on_text(config[CONF_ON_TEXT]))
+        cg.add(var.set_off_text(config[CONF_OFF_TEXT]))
+
+    if config.get(CONF_TYPE) == CONF_SENSOR:
+        cg.add(var.set_no_data_text(config[CONF_NO_DATA_TEXT]))
+        cg.add(var.set_accuracy(config[CONF_ACCURACY]))
+
+    if config.get(CONF_TYPE) == CONF_BINARY_SENSOR:
+        cg.add(var.set_on_text(config[CONF_ON_TEXT]))
+        cg.add(var.set_off_text(config[CONF_OFF_TEXT]))
+        cg.add(var.set_no_data_text(config[CONF_NO_DATA_TEXT]))
+
+    if group_config := config.get(CONF_GROUPS):
+        await groups.add_groups_to_storage(var, group_config)
+
+
+async def to_code(config):
+    for render in config:
+        var = cg.new_Pvariable(render[CONF_ID])
+        await render_to_code(var, render)

--- a/esphome/components/display_menu_render_base/display_menu_render.cpp
+++ b/esphome/components/display_menu_render_base/display_menu_render.cpp
@@ -1,0 +1,50 @@
+#include "display_menu_render.h"
+
+namespace esphome {
+namespace display_menu_render_base {
+
+#ifdef USE_SENSOR
+size_t SensorMenuRender::render_entity(MenuItemMenu *menu, EntityBase *entity) {
+  sensor::Sensor *sensor_obj = static_cast<sensor::Sensor *>(entity);
+  MenuItemValue *item = new MenuItemValue();
+  item->set_text([sensor_obj](const MenuItem *item) { return sensor_obj->get_name(); });
+  item->set_value_lambda([sensor_obj, this](const display_menu_base::MenuItem *it) -> std::string {
+    return sensor_obj->state_to_string(this->no_data_text_.c_str());
+  });
+  menu->add_generated_items(item);
+  return 1;
+}
+#endif
+
+#ifdef USE_SWITCH
+size_t SwitchMenuRender::render_entity(MenuItemMenu *menu, EntityBase *entity) {
+  switch_::Switch *switch_obj = static_cast<switch_::Switch *>(entity);
+  MenuItemSwitch *menu_switch = new MenuItemSwitch();
+  menu_switch->set_text([switch_obj](const MenuItem *item) { return switch_obj->get_name(); });
+  menu_switch->set_immediate_edit(true);
+  menu_switch->set_switch_variable(switch_obj);
+  menu_switch->set_on_text(this->on_text_.c_str());
+  menu_switch->set_off_text(this->off_text_.c_str());
+
+  menu->add_generated_items(menu_switch);
+  return 1;
+}
+#endif
+
+#ifdef USE_BINARY_SENSOR
+size_t BinarySensorMenuRender::render_entity(MenuItemMenu *menu, EntityBase *entity) {
+  auto *sensor_obj = static_cast<binary_sensor::BinarySensor *>(entity);
+  MenuItemBinarySensor *item = new MenuItemBinarySensor();
+  item->set_text([sensor_obj](const MenuItem *item) { return sensor_obj->get_name(); });
+  item->set_binary_sensor_variable(sensor_obj);
+  item->set_on_text(this->on_text_.c_str());
+  item->set_off_text(this->off_text_.c_str());
+  item->set_no_data_text(this->no_data_text_.c_str());
+
+  menu->add_generated_items(item);
+  return 1;
+}
+#endif
+
+}  // namespace display_menu_render_base
+}  // namespace esphome

--- a/esphome/components/display_menu_render_base/display_menu_render.h
+++ b/esphome/components/display_menu_render_base/display_menu_render.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include "display_menu_render_base.h"
+
+#ifdef USE_SENSOR
+#include "esphome/components/sensor/sensor.h"
+#endif
+
+#ifdef USE_SWITCH
+#include "esphome/components/switch/switch.h"
+#endif
+
+#ifdef USE_BINARY_SENSOR
+#include "esphome/components/binary_sensor/binary_sensor.h"
+#endif
+
+namespace esphome {
+namespace display_menu_render_base {
+
+using namespace display_menu_base;
+
+#ifdef USE_SENSOR
+// Default render for sensor objects
+class SensorMenuRender : public MenuRenderInterface {
+ public:
+  SensorMenuRender() : MenuRenderInterface(EntityType::SENSOR) {}
+  size_t render_entity(MenuItemMenu *menu, EntityBase *entity) override;
+
+  void set_accuracy(int accuracy) { this->accuracy_ = accuracy; }
+  void set_no_data_text(const char *text) { this->no_data_text_ = StringRef(text); }
+
+ protected:
+  int accuracy_;
+  StringRef no_data_text_;
+};
+#endif
+
+#ifdef USE_SWITCH
+
+// Default render for switch objects
+class SwitchMenuRender : public MenuRenderInterface {
+ public:
+  SwitchMenuRender() : MenuRenderInterface(EntityType::SWITCH) {}
+  size_t render_entity(MenuItemMenu *menu, EntityBase *entity) override;
+
+  void set_on_text(const char *text) { this->on_text_ = StringRef(text); }
+  void set_off_text(const char *text) { this->off_text_ = StringRef(text); }
+
+ protected:
+  StringRef on_text_;
+  StringRef off_text_;
+};
+#endif
+
+#ifdef USE_BINARY_SENSOR
+// Default render for binary sensor objects
+class BinarySensorMenuRender : public MenuRenderInterface {
+ public:
+  BinarySensorMenuRender() : MenuRenderInterface(EntityType::BINARY_SENSOR) {}
+  size_t render_entity(MenuItemMenu *menu, EntityBase *entity) override;
+
+  void set_on_text(const char *text) { this->on_text_ = StringRef(text); }
+  void set_off_text(const char *text) { this->off_text_ = StringRef(text); }
+  void set_no_data_text(const char *text) { this->no_data_text_ = StringRef(text); }
+
+ protected:
+  StringRef on_text_;
+  StringRef off_text_;
+  StringRef no_data_text_;
+};
+
+#endif
+
+// Render with lambda
+class LambdaMenuRender : public MenuRenderInterface {
+ public:
+  // Render lambda should return num of added elements in menu args
+  using render_lambda_t = std::function<size_t(MenuItemMenu *menu, EntityBase *entity)>;
+
+  LambdaMenuRender() : MenuRenderInterface(EntityType::NONE) {}
+  size_t render_entity(MenuItemMenu *menu, EntityBase *entity) override {
+    if (lambda_)
+      return lambda_(menu, entity);
+    return 0;
+  }
+  void set_lambda(render_lambda_t &&lambda) { this->lambda_ = lambda; }
+  render_lambda_t lambda_;
+};
+
+}  // namespace display_menu_render_base
+}  // namespace esphome

--- a/esphome/components/display_menu_render_base/display_menu_render_base.h
+++ b/esphome/components/display_menu_render_base/display_menu_render_base.h
@@ -1,0 +1,34 @@
+#pragma once
+#include "esphome/components/groups/groups.h"
+#include "esphome/components/display_menu_base/menu_item.h"
+
+namespace esphome {
+namespace display_menu_render_base {
+
+using namespace display_menu_base;
+
+// Render interface for menu with groups or by entity type
+class MenuRenderInterface : public groups::GroupsStorage {
+ public:
+  MenuRenderInterface(EntityType type = EntityType::NONE) : type_(type){};
+
+  EntityType type() const { return type_; }
+  void set_type(EntityType type) { this->type_ = type; }
+
+  // Add needed items in menu with entity_info
+  virtual size_t render_entity(MenuItemMenu *menu, EntityBase *entity) = 0;
+
+  bool has_entity(EntityBase *entity) const {
+    for (auto *group : this->groups_) {
+      if (group->has_entity(entity))
+        return true;
+    }
+    return false;
+  }
+
+ protected:
+  EntityType type_;
+};
+
+}  // namespace display_menu_render_base
+}  // namespace esphome


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `display_menu_render_base` with default renders for sensors, switches, and binary sensors plus lambda-based rendering, and rename `on_value_` to `on_value` across menu items.
> 
> - **Display Menu Rendering**:
>   - Add `display_menu_render_base` module with render interface `MenuRenderInterface` (`display_menu_render_base/display_menu_render_base.h`).
>   - Implement default entity renderers (`display_menu_render_base/display_menu_render.h/.cpp`):
>     - `SensorMenuRender` outputs `MenuItemValue` with sensor state.
>     - `SwitchMenuRender` outputs `MenuItemSwitch` with immediate edit and custom on/off text.
>     - `BinarySensorMenuRender` outputs `MenuItemBinarySensor` with on/off/no-data texts.
>   - Add lambda-based renderer `LambdaMenuRender` for custom menu item generation.
>   - Add Python config/schema (`display_menu_render_base/__init__.py`) to register renders, support groups, lambda, entity type, and renderer-specific options.
> - **Menu Item API**:
>   - Rename callback method `on_value_` to `on_value` in `display_menu_base/menu_item.h/.cpp` and update all call sites (`Select`, `Number`, `Switch`, `Command`, `Custom`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fe2911aecb5754156ef985b21f34a85d0ee865cd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->