### PR TITLE
[display] Add main page option

### DIFF
--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -133,9 +133,11 @@ async def setup_display_core_(var, config):
             page = cg.new_Pvariable(conf[CONF_ID], lambda_)
             pages.append(page)
         cg.add(var.set_pages(pages))
-    if CONF_MAIN_PAGE in config:
-        page = await cg.get_variable(config[CONF_MAIN_PAGE])
-        cg.add(var.set_main_page(page))
+        if CONF_MAIN_PAGE in config:
+            page = await cg.get_variable(config[CONF_MAIN_PAGE])
+            cg.add(var.set_main_page(page))
+        else:
+            cg.add(var.set_main_page(pages[0]))
     for conf in config.get(CONF_ON_PAGE_CHANGE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         if CONF_FROM in conf:

--- a/esphome/components/display/__init__.py
+++ b/esphome/components/display/__init__.py
@@ -42,6 +42,7 @@ DisplayOnPageChangeTrigger = display_ns.class_(
 CONF_ON_PAGE_CHANGE = "on_page_change"
 CONF_SHOW_TEST_CARD = "show_test_card"
 CONF_UNSPECIFIED = "unspecified"
+CONF_MAIN_PAGE = "main_page"
 
 DISPLAY_ROTATIONS = {
     0: display_ns.DISPLAY_ROTATION_0_DEGREES,
@@ -93,6 +94,7 @@ FULL_DISPLAY_SCHEMA = BASIC_DISPLAY_SCHEMA.extend(
             ),
             cv.Length(min=1),
         ),
+        cv.Optional(CONF_MAIN_PAGE): cv.use_id(DisplayPage),
         cv.Optional(CONF_ON_PAGE_CHANGE): automation.validate_automation(
             {
                 cv.GenerateID(CONF_TRIGGER_ID): cv.declare_id(
@@ -131,6 +133,9 @@ async def setup_display_core_(var, config):
             page = cg.new_Pvariable(conf[CONF_ID], lambda_)
             pages.append(page)
         cg.add(var.set_pages(pages))
+    if CONF_MAIN_PAGE in config:
+        page = await cg.get_variable(config[CONF_MAIN_PAGE])
+        cg.add(var.set_main_page(page))
     for conf in config.get(CONF_ON_PAGE_CHANGE, []):
         trigger = cg.new_Pvariable(conf[CONF_TRIGGER_ID], var)
         if CONF_FROM in conf:

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -738,7 +738,10 @@ void Display::set_pages(std::vector<DisplayPage *> pages) {
   }
   pages[0]->set_prev(pages[pages.size() - 1]);
   pages[pages.size() - 1]->set_next(pages[0]);
-  this->show_page(pages[0]);
+
+  if (this->main_page_ == nullptr) {
+    this->show_page(pages[0]);
+  }
 }
 void Display::show_page(DisplayPage *page) {
   this->previous_page_ = this->page_;
@@ -747,6 +750,10 @@ void Display::show_page(DisplayPage *page) {
     for (auto *t : on_page_change_triggers_)
       t->process(this->previous_page_, this->page_);
   }
+}
+void Display::set_main_page(DisplayPage *page) {
+  this->main_page_ = page;
+  this->show_page(page);
 }
 void Display::show_next_page() { this->page_->show_next(); }
 void Display::show_prev_page() { this->page_->show_prev(); }

--- a/esphome/components/display/display.cpp
+++ b/esphome/components/display/display.cpp
@@ -738,10 +738,6 @@ void Display::set_pages(std::vector<DisplayPage *> pages) {
   }
   pages[0]->set_prev(pages[pages.size() - 1]);
   pages[pages.size() - 1]->set_next(pages[0]);
-
-  if (this->main_page_ == nullptr) {
-    this->show_page(pages[0]);
-  }
 }
 void Display::show_page(DisplayPage *page) {
   this->previous_page_ = this->page_;

--- a/esphome/components/display/display.h
+++ b/esphome/components/display/display.h
@@ -611,6 +611,9 @@ class Display : public PollingComponent {
 
   const DisplayPage *get_active_page() const { return this->page_; }
 
+  void set_main_page(DisplayPage *page);
+  DisplayPage *get_main_page() const { return this->main_page_; }
+
   void add_on_page_change_trigger(DisplayOnPageChangeTrigger *t) { this->on_page_change_triggers_.push_back(t); }
 
   /// Internal method to set the display rotation with.
@@ -701,6 +704,7 @@ class Display : public PollingComponent {
   optional<display_writer_t> writer_{};
   DisplayPage *page_{nullptr};
   DisplayPage *previous_page_{nullptr};
+  DisplayPage *main_page_{nullptr};
   std::vector<DisplayOnPageChangeTrigger *> on_page_change_triggers_;
   bool auto_clear_enabled_{true};
   std::vector<Rect> clipping_rectangle_;


### PR DESCRIPTION
# What does this implement/fix?

[JXD-371] split display pages

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces explicit control of the initial display page.
> 
> - Adds `CONF_MAIN_PAGE` to YAML schema; when `pages` are defined, sets main page to the specified page or defaults to the first page
> - Implements `Display::set_main_page()` and `get_main_page()` with backing `main_page_`; calling `set_main_page()` also shows that page
> - Changes initialization: removes auto `show_page(pages[0])` from `set_pages()`; initial page is now set via `set_main_page()`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93cca63b2634118ea33680fa8b319a05eb048cb6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->