### PR TITLE
[aplication] Fixes bugs with dynamic added components

### DIFF
--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -73,16 +73,27 @@ void Application::register_component_(Component *comp) {
   // If looping_components_ is already initialized (setup has started/completed),
   // we need to add this component to the looping list if it has a loop() override.
   // Components registered during normal setup flow are handled by calculate_looping_components_().
-  if (!this->looping_components_.empty() && comp->has_overridden_loop()) {
-    // Add to active section by inserting at active_end_ position and incrementing
+  if (this->looping_components_initialized_ && comp->has_overridden_loop()) {
     this->looping_components_.push_back(comp);
-    // Swap with inactive section if needed to maintain partitioning
-    if (this->looping_components_active_end_ < this->looping_components_.size() - 1) {
-      std::swap(this->looping_components_[this->looping_components_active_end_], this->looping_components_.back());
+
+    // Check if the component is in LOOP_DONE state (e.g., called disable_loop() during initialization)
+    // Components in LOOP_DONE state go to the inactive section (end of vector)
+    // Components NOT in LOOP_DONE state go to the active section
+    // This matches the partitioning logic in add_looping_components_by_state_()
+    if ((comp->get_component_state() & COMPONENT_STATE_MASK) == COMPONENT_STATE_LOOP_DONE) {
+      // Component is in LOOP_DONE state - leave it at the end (inactive section)
+      // enable_component_loop_() will find it there when enable_loop() is called
+      ESP_LOGD(TAG, "Late-registered component %s added to inactive looping components (LOOP_DONE state)",
+               LOG_STR_ARG(comp->get_component_log_str()));
+    } else {
+      // Component is active - swap with inactive section if needed to maintain partitioning
+      if (this->looping_components_active_end_ < this->looping_components_.size() - 1) {
+        std::swap(this->looping_components_[this->looping_components_active_end_], this->looping_components_.back());
+      }
+      this->looping_components_active_end_++;
+      ESP_LOGD(TAG, "Late-registered component %s added to active looping components (active_end=%u)",
+               LOG_STR_ARG(comp->get_component_log_str()), this->looping_components_active_end_);
     }
-    this->looping_components_active_end_++;
-    ESP_LOGD(TAG, "Late-registered component %s added to looping components (active_end=%u)",
-             LOG_STR_ARG(comp->get_component_log_str()), this->looping_components_active_end_);
   }
 #endif
 }
@@ -383,6 +394,9 @@ void Application::calculate_looping_components_() {
   // Then add any components that are already LOOP_DONE to the inactive section
   // This handles components that called disable_loop() during initialization
   this->add_looping_components_by_state_(true);
+
+  // Mark looping_components_ as initialized so late-registered components can be added
+  this->looping_components_initialized_ = true;
 }
 
 void Application::add_looping_components_by_state_(bool match_loop_done) {

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -68,6 +68,23 @@ void Application::register_component_(Component *comp) {
     }
   }
   this->components_.push_back(comp);
+
+#ifdef JETHOME_USE_DYNAMIC_VECTORS
+  // If looping_components_ is already initialized (setup has started/completed),
+  // we need to add this component to the looping list if it has a loop() override.
+  // Components registered during normal setup flow are handled by calculate_looping_components_().
+  if (!this->looping_components_.empty() && comp->has_overridden_loop()) {
+    // Add to active section by inserting at active_end_ position and incrementing
+    this->looping_components_.push_back(comp);
+    // Swap with inactive section if needed to maintain partitioning
+    if (this->looping_components_active_end_ < this->looping_components_.size() - 1) {
+      std::swap(this->looping_components_[this->looping_components_active_end_], this->looping_components_.back());
+    }
+    this->looping_components_active_end_++;
+    ESP_LOGD(TAG, "Late-registered component %s added to looping components (active_end=%u)",
+             LOG_STR_ARG(comp->get_component_log_str()), this->looping_components_active_end_);
+  }
+#endif
 }
 void Application::setup() {
   ESP_LOGI(TAG, "Running through setup()");

--- a/esphome/core/application.cpp
+++ b/esphome/core/application.cpp
@@ -252,10 +252,12 @@ void Application::run_powerdown_hooks() {
 void Application::teardown_components(uint32_t timeout_ms) {
   uint32_t start_time = millis();
 
-  // Use a StaticVector instead of std::vector to avoid heap allocation
-  // since we know the actual size at compile time
-  StaticVector<Component *, ESPHOME_COMPONENT_COUNT> pending_components;
-
+  // Use AppObjectVector which is StaticVector by default (avoids heap allocation),
+  // or std::vector when JETHOME_USE_DYNAMIC_VECTORS is defined
+  AppObjectVector<Component *, ESPHOME_COMPONENT_COUNT> pending_components;
+#ifdef JETHOME_USE_DYNAMIC_VECTORS
+  pending_components.resize(this->components_.size());
+#endif
   // Copy all components in reverse order
   // Reverse order matches the behavior of run_safe_shutdown_hooks() above and ensures
   // components are torn down in the opposite order of their setup_priority (which is

--- a/esphome/core/application.h
+++ b/esphome/core/application.h
@@ -666,6 +666,7 @@ class Application {
   uint8_t app_state_{0};
   bool name_add_mac_suffix_;
   bool in_loop_{false};
+  bool looping_components_initialized_{false};  // True after calculate_looping_components_() has been called
   volatile bool has_pending_enable_loop_requests_{false};
 
 #ifdef USE_SOCKET_SELECT_SUPPORT


### PR DESCRIPTION
# What does this implement/fix?

Fixes bugs with dynamic added components

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves core handling of dynamically added components and teardown flow.
> 
> - Late-registered components with `loop()` are added to `looping_components_` with correct active/inactive partitioning; gated by `JETHOME_USE_DYNAMIC_VECTORS`
> - Adds `looping_components_initialized_` flag and sets it in `calculate_looping_components_()` to support safe late registration
> - `teardown_components()` now uses `AppObjectVector<Component*, ESPHOME_COMPONENT_COUNT>` and resizes under dynamic vectors while preserving reverse-order teardown
> - Minor logging and state updates around loop enable/disable and initialization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 944b617f99417b949c366df0e67ef61db0665f6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->