### PR TITLE
[build] Add command to clean CMakeCache.txt files

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -821,6 +821,25 @@ def command_clean(args: ArgsProtocol, config: ConfigType) -> int | None:
     return 0
 
 
+def command_clean_cmake_cache(args: ArgsProtocol, config: ConfigType) -> int | None:
+    try:
+        build_path = CORE.build_path
+        count = 0
+        for cmake_cache in build_path.rglob("CMakeCache.txt"):
+            _LOGGER.info("Removing %s", cmake_cache)
+            cmake_cache.unlink()
+            count += 1
+        if count == 0:
+            _LOGGER.info("No CMakeCache.txt files found.")
+        else:
+            _LOGGER.info("Removed %d CMakeCache.txt file(s).", count)
+    except OSError as err:
+        _LOGGER.error("Error removing CMakeCache.txt: %s", err)
+        return 1
+    _LOGGER.info("Done!")
+    return 0
+
+
 def command_dashboard(args: ArgsProtocol) -> int | None:
     from esphome.dashboard import dashboard
 
@@ -1000,6 +1019,7 @@ POST_CONFIG_ACTIONS = {
     "logs": command_logs,
     "run": command_run,
     "clean": command_clean,
+    "clean-cmake-cache": command_clean_cmake_cache,
     "clean-mqtt": command_clean_mqtt,
     "mqtt-fingerprint": command_mqtt_fingerprint,
     "idedata": command_idedata,
@@ -1009,6 +1029,7 @@ POST_CONFIG_ACTIONS = {
 
 SIMPLE_CONFIG_ACTIONS = [
     "clean",
+    "clean-cmake-cache",
     "clean-mqtt",
     "config",
 ]
@@ -1217,6 +1238,14 @@ def parse_args(argv):
         "clean", help="Delete all temporary build files."
     )
     parser_clean.add_argument(
+        "configuration", help="Your YAML configuration file(s).", nargs="+"
+    )
+
+    parser_clean_cmake_cache = subparsers.add_parser(
+        "clean-cmake-cache",
+        help="Delete CMakeCache.txt files from the build directory.",
+    )
+    parser_clean_cmake_cache.add_argument(
         "configuration", help="Your YAML configuration file(s).", nargs="+"
     )
 


### PR DESCRIPTION
# What does this implement/fix?

Removing CMakeCache.txt files is more faster than clean.
Need for develop, when you change your source files

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a focused cleanup command to clear stale CMake cache files without removing full build artifacts.
> 
> - Adds `command_clean_cmake_cache` to delete `CMakeCache.txt` recursively under `CORE.build_path` with informative logging
> - Wires new action into CLI: `esphome clean-cmake-cache <configuration>` via argparse, `POST_CONFIG_ACTIONS`, and `SIMPLE_CONFIG_ACTIONS`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b651873b3a56bcff011eea4bdf55ce4e8fc74214. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->