### PR TITLE
[JXD-384] Add visibility control for menu items

### DIFF
--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -27,11 +27,11 @@ from esphome.const import (
     CONF_TRIGGER_ID,
     CONF_TYPE,
     CONF_VALUE,
+    CONF_VISIBLE,
 )
 
 CONF_GENERATE_LAMBDA = "generate_lambda"
 CONF_GENERATE_ON_ENTER = "generate_on_enter"
-CONF_VISIBLE = "visible"
 
 CODEOWNERS = ["@numo68"]
 

--- a/esphome/components/display_menu_base/__init__.py
+++ b/esphome/components/display_menu_base/__init__.py
@@ -31,6 +31,7 @@ from esphome.const import (
 
 CONF_GENERATE_LAMBDA = "generate_lambda"
 CONF_GENERATE_ON_ENTER = "generate_on_enter"
+CONF_VISIBLE = "visible"
 
 CODEOWNERS = ["@numo68"]
 
@@ -88,6 +89,9 @@ ShowAction = display_menu_base_ns.class_("ShowAction", automation.Action)
 HideAction = display_menu_base_ns.class_("HideAction", automation.Action)
 BackAction = display_menu_base_ns.class_("BackAction", automation.Action)
 ShowMainAction = display_menu_base_ns.class_("ShowMainAction", automation.Action)
+SetItemVisibleAction = display_menu_base_ns.class_(
+    "SetItemVisibleAction", automation.Action
+)
 
 IsActiveCondition = display_menu_base_ns.class_(
     "IsActiveCondition", automation.Condition
@@ -176,6 +180,7 @@ def menu_item_schema(value):
 MENU_ITEM_COMMON_SCHEMA = cv.Schema(
     {
         cv.Optional(CONF_TEXT): cv.templatable(cv.string),
+        cv.Optional(CONF_VISIBLE, default=True): cv.boolean,
     }
 )
 
@@ -426,6 +431,27 @@ async def display_menu_is_active_to_code(config, condition_id, template_arg, arg
     return cg.new_Pvariable(condition_id, template_arg, paren)
 
 
+MENU_ITEM_SET_VISIBLE_ACTION_SCHEMA = cv.Schema(
+    {
+        cv.Required(CONF_ID): cv.use_id(MenuItem),
+        cv.Required(CONF_VISIBLE): cv.templatable(cv.boolean),
+    }
+)
+
+
+@automation.register_action(
+    "display_menu_item.set_visible",
+    SetItemVisibleAction,
+    MENU_ITEM_SET_VISIBLE_ACTION_SCHEMA,
+)
+async def menu_item_set_visible_to_code(config, action_id, template_arg, args):
+    item = await cg.get_variable(config[CONF_ID])
+    var = cg.new_Pvariable(action_id, template_arg, item)
+    template_ = await cg.templatable(config[CONF_VISIBLE], args, cg.bool_)
+    cg.add(var.set_visible(template_))
+    return var
+
+
 async def menu_item_to_code(menu, config, parent):
     if config[CONF_TYPE] in MENU_ITEMS_WITH_SPECIALIZED_CLASSES:
         item = cg.new_Pvariable(config[CONF_ID])
@@ -440,6 +466,8 @@ async def menu_item_to_code(menu, config, parent):
             cg.add(item.set_text(template_))
         else:
             cg.add(item.set_text(config[CONF_TEXT]))
+    if not config.get(CONF_VISIBLE, True):
+        cg.add(item.set_visible(False))
     if CONF_VALUE_LAMBDA in config:
         template_ = await cg.process_lambda(
             config[CONF_VALUE_LAMBDA],

--- a/esphome/components/display_menu_base/automation.h
+++ b/esphome/components/display_menu_base/automation.h
@@ -104,6 +104,18 @@ template<typename... Ts> class IsActiveCondition : public Condition<Ts...> {
   DisplayMenuComponent *menu_;
 };
 
+template<typename... Ts> class SetItemVisibleAction : public Action<Ts...> {
+ public:
+  explicit SetItemVisibleAction(MenuItem *item) : item_(item) {}
+
+  TEMPLATABLE_VALUE(bool, visible)
+
+  void play(Ts... x) override { this->item_->set_visible(this->visible_.value(x...)); }
+
+ protected:
+  MenuItem *item_;
+};
+
 class DisplayMenuOnEnterTrigger : public Trigger<const MenuItem *> {
  public:
   explicit DisplayMenuOnEnterTrigger(MenuItem *parent) {

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -353,7 +353,8 @@ void DisplayMenuComponent::hide() {
 
 void DisplayMenuComponent::reset_() {
   this->displayed_item_ = this->root_item_;
-  this->cursor_index_ = this->top_index_ = 0;
+  auto first_visible = this->find_first_visible_();
+  this->cursor_index_ = this->top_index_ = first_visible.value_or(0);
   this->selection_stack_.clear();
 }
 
@@ -373,34 +374,56 @@ bool DisplayMenuComponent::check_healthy_and_active_() {
   return this->active_;
 }
 
+optional<size_t> DisplayMenuComponent::find_next_visible_(size_t start) {
+  for (size_t i = start; i < this->displayed_item_->items_size(); i++) {
+    if (this->displayed_item_->get_item(i)->is_visible()) {
+      return i;
+    }
+  }
+  return {};
+}
+
+optional<size_t> DisplayMenuComponent::find_prev_visible_(size_t start) {
+  for (size_t i = start + 1; i > 0; i--) {
+    if (this->displayed_item_->get_item(i - 1)->is_visible()) {
+      return i - 1;
+    }
+  }
+  return {};
+}
+
+optional<size_t> DisplayMenuComponent::find_first_visible_() { return this->find_next_visible_(0); }
+
 bool DisplayMenuComponent::cursor_up_() {
-  bool changed = false;
-
-  if (this->cursor_index_ > 0) {
-    changed = true;
-
-    --this->cursor_index_;
-
-    if (this->cursor_index_ < this->top_index_)
-      this->top_index_ = this->cursor_index_;
+  if (this->cursor_index_ == 0) {
+    return false;
   }
 
-  return changed;
+  auto prev = this->find_prev_visible_(this->cursor_index_ - 1);
+  if (!prev.has_value()) {
+    return false;
+  }
+
+  this->cursor_index_ = prev.value();
+
+  if (this->cursor_index_ < this->top_index_)
+    this->top_index_ = this->cursor_index_;
+
+  return true;
 }
 
 bool DisplayMenuComponent::cursor_down_() {
-  bool changed = false;
-
-  if (this->cursor_index_ + 1 < this->displayed_item_->items_size()) {
-    changed = true;
-
-    ++this->cursor_index_;
-
-    if (this->cursor_index_ >= this->top_index_ + this->rows_)
-      this->top_index_ = this->cursor_index_ - this->rows_ + 1;
+  auto next = this->find_next_visible_(this->cursor_index_ + 1);
+  if (!next.has_value()) {
+    return false;
   }
 
-  return changed;
+  this->cursor_index_ = next.value();
+
+  if (this->cursor_index_ >= this->top_index_ + this->rows_)
+    this->top_index_ = this->cursor_index_ - this->rows_ + 1;
+
+  return true;
 }
 
 bool DisplayMenuComponent::enter_menu_() {
@@ -411,7 +434,8 @@ bool DisplayMenuComponent::enter_menu_() {
     this->generate_to_menu_items_(static_cast<MenuItemMenu *>(item));
   }
   this->selection_stack_.emplace_front(this->top_index_, this->cursor_index_);
-  this->cursor_index_ = this->top_index_ = 0;
+  auto first_visible = this->find_first_visible_();
+  this->cursor_index_ = this->top_index_ = first_visible.value_or(0);
   this->displayed_item_->on_enter();
 
   return true;
@@ -443,6 +467,18 @@ bool DisplayMenuComponent::leave_menu_() {
         this->cursor_index_ = menu_item->items_size() - 1;
       }
     }
+
+    // Ensure cursor is on a visible item
+    if (!this->displayed_item_->get_item(this->cursor_index_)->is_visible()) {
+      auto next = this->find_next_visible_(this->cursor_index_);
+      if (next.has_value()) {
+        this->cursor_index_ = next.value();
+      } else {
+        auto prev = this->find_prev_visible_(this->cursor_index_);
+        this->cursor_index_ = prev.value_or(0);
+      }
+    }
+
     this->displayed_item_->on_enter();
     changed = true;
   }
@@ -466,9 +502,14 @@ void DisplayMenuComponent::finish_editing_() {
 }
 
 void DisplayMenuComponent::draw_menu() {
-  for (size_t i = 0; i < this->rows_ && this->top_index_ + i < this->displayed_item_->items_size(); ++i) {
-    this->draw_item(this->displayed_item_->get_item(this->top_index_ + i), i,
-                    this->top_index_ + i == this->cursor_index_);
+  uint8_t row = 0;
+  for (size_t i = this->top_index_; i < this->displayed_item_->items_size() && row < this->rows_; ++i) {
+    MenuItem *item = this->displayed_item_->get_item(i);
+    if (!item->is_visible()) {
+      continue;
+    }
+    this->draw_item(item, row, i == this->cursor_index_);
+    ++row;
   }
 }
 

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -374,6 +374,29 @@ bool DisplayMenuComponent::check_healthy_and_active_() {
   return this->active_;
 }
 
+void DisplayMenuComponent::ensure_cursor_visible_() {
+  if (this->displayed_item_->items_size() == 0)
+    return;
+
+  if (this->cursor_index_ >= this->displayed_item_->items_size())
+    this->cursor_index_ = this->displayed_item_->items_size() - 1;
+
+  if (!this->displayed_item_->get_item(this->cursor_index_)->is_visible()) {
+    auto next = this->find_next_visible_(this->cursor_index_);
+    if (next.has_value()) {
+      this->cursor_index_ = next.value();
+    } else {
+      auto prev = this->find_prev_visible_(this->cursor_index_);
+      this->cursor_index_ = prev.value_or(0);
+    }
+
+    if (this->cursor_index_ < this->top_index_)
+      this->top_index_ = this->cursor_index_;
+    else if (this->cursor_index_ >= this->top_index_ + this->rows_)
+      this->top_index_ = this->cursor_index_ - this->rows_ + 1;
+  }
+}
+
 optional<size_t> DisplayMenuComponent::find_next_visible_(size_t start) {
   for (size_t i = start; i < this->displayed_item_->items_size(); i++) {
     if (this->displayed_item_->get_item(i)->is_visible()) {
@@ -461,29 +484,9 @@ bool DisplayMenuComponent::leave_menu_() {
       auto *menu_item = static_cast<MenuItemMenu *>(item);
       menu_item->clear_items();
       this->generate_to_menu_items_(menu_item);
-
-      // Fix cursor if some items were deleted
-      if (this->cursor_index_ >= menu_item->items_size()) {
-        this->cursor_index_ = menu_item->items_size() - 1;
-      }
     }
 
-    // Ensure cursor is on a visible item
-    if (!this->displayed_item_->get_item(this->cursor_index_)->is_visible()) {
-      auto next = this->find_next_visible_(this->cursor_index_);
-      if (next.has_value()) {
-        this->cursor_index_ = next.value();
-      } else {
-        auto prev = this->find_prev_visible_(this->cursor_index_);
-        this->cursor_index_ = prev.value_or(0);
-      }
-    }
-
-    // Keep top_index_ consistent with cursor after visibility adjustment
-    if (this->cursor_index_ < this->top_index_)
-      this->top_index_ = this->cursor_index_;
-    else if (this->cursor_index_ >= this->top_index_ + this->rows_)
-      this->top_index_ = this->cursor_index_ - this->rows_ + 1;
+    this->ensure_cursor_visible_();
 
     this->displayed_item_->on_enter();
     changed = true;

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -479,6 +479,12 @@ bool DisplayMenuComponent::leave_menu_() {
       }
     }
 
+    // Keep top_index_ consistent with cursor after visibility adjustment
+    if (this->cursor_index_ < this->top_index_)
+      this->top_index_ = this->cursor_index_;
+    else if (this->cursor_index_ >= this->top_index_ + this->rows_)
+      this->top_index_ = this->cursor_index_ - this->rows_ + 1;
+
     this->displayed_item_->on_enter();
     changed = true;
   }

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -390,10 +390,11 @@ void DisplayMenuComponent::ensure_cursor_visible_() {
       this->cursor_index_ = prev.value_or(0);
     }
 
-    if (this->cursor_index_ < this->top_index_)
+    if (this->cursor_index_ < this->top_index_) {
       this->top_index_ = this->cursor_index_;
-    else if (this->cursor_index_ >= this->top_index_ + this->rows_)
+    } else if (this->cursor_index_ >= this->top_index_ + this->rows_) {
       this->top_index_ = this->cursor_index_ - this->rows_ + 1;
+    }
   }
 }
 

--- a/esphome/components/display_menu_base/display_menu_base.h
+++ b/esphome/components/display_menu_base/display_menu_base.h
@@ -64,6 +64,7 @@ class DisplayMenuComponent : public Component {
   void reset_();
   void process_initial_();
   bool check_healthy_and_active_();
+  void ensure_cursor_visible_();
   MenuItem *get_selected_item_() { return this->displayed_item_->get_item(this->cursor_index_); }
   bool cursor_up_();
   bool cursor_down_();
@@ -77,6 +78,7 @@ class DisplayMenuComponent : public Component {
   virtual void draw_item(const MenuItem *item, uint8_t row, bool selected) = 0;
   virtual void update() {}
   virtual void draw_and_update() {
+    ensure_cursor_visible_();
     draw_menu();
     update();
   }

--- a/esphome/components/display_menu_base/display_menu_base.h
+++ b/esphome/components/display_menu_base/display_menu_base.h
@@ -67,6 +67,9 @@ class DisplayMenuComponent : public Component {
   MenuItem *get_selected_item_() { return this->displayed_item_->get_item(this->cursor_index_); }
   bool cursor_up_();
   bool cursor_down_();
+  optional<size_t> find_next_visible_(size_t start);
+  optional<size_t> find_prev_visible_(size_t start);
+  optional<size_t> find_first_visible_();
   bool enter_menu_();
   bool leave_menu_();
   void finish_editing_();

--- a/esphome/components/display_menu_base/menu_item.h
+++ b/esphome/components/display_menu_base/menu_item.h
@@ -50,6 +50,9 @@ class MenuItem {
   std::string get_text() const { return const_cast<MenuItem *>(this)->text_.value(this); }
   virtual bool get_immediate_edit() const { return false; }
 
+  bool is_visible() const { return this->visible_; }
+  void set_visible(bool visible) { this->visible_ = visible; }
+
   virtual bool has_value() const { return false; }
   virtual std::string get_value_text() const { return ""; }
 
@@ -100,6 +103,15 @@ class MenuItem {
   size_t items_size() const { return this->items_.size(); }
   MenuItem *get_item(size_t i) const { return this->items_[i]; }
 
+  size_t visible_items_size() const {
+    size_t count = 0;
+    for (const auto *item : this->items_) {
+      if (item->is_visible())
+        count++;
+    }
+    return count;
+  }
+
   std::vector<MenuItem *> &items() { return items_; }
 
   virtual bool select_next() { return false; }
@@ -120,6 +132,7 @@ class MenuItem {
 
   std::vector<MenuItem *> items_;
   bool has_internal_items_{false};
+  bool visible_{true};
 };
 
 class MenuItemValueBase : public MenuItem {

--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -126,15 +126,23 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
 
   // First pass: measure only visible items and collect their indices
   bool first_visible = true;
+  size_t cursor_visible_pos = 0;
+  bool cursor_found = false;
   for (size_t i = 0; max_item_index >= 0 && i <= static_cast<size_t>(max_item_index); i++) {
     const auto *item = this->displayed_item_->get_item(i);
     if (!item->is_visible()) {
       continue;
     }
 
+    size_t visible_pos = visible_indices.size();
     visible_indices.push_back(i);
     const bool selected = i == this->cursor_index_;
     const display::Rect item_dimensions = this->measure_item(display, item, bounds, selected);
+
+    if (selected) {
+      cursor_visible_pos = visible_pos;
+      cursor_found = true;
+    }
 
     menu_dimensions.push_back(item_dimensions);
     total_height += item_dimensions.h + (first_visible ? 0 : y_padding);
@@ -144,8 +152,7 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
     if (total_height <= bounds->h) {
       number_items_fit_to_screen++;
     } else {
-      // Scroll the display if the selected item or the item immediately after it overflows
-      if ((selected) || (i == this->cursor_index_ + 1)) {
+      if ((selected) || (cursor_found && visible_pos == cursor_visible_pos + 1)) {
         scroll_menu_items = true;
       }
     }
@@ -155,27 +162,18 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
     return;
   }
 
-  // Find cursor position in visible indices
-  size_t cursor_visible_index = 0;
-  for (size_t vi = 0; vi < visible_indices.size(); vi++) {
-    if (visible_indices[vi] == this->cursor_index_) {
-      cursor_visible_index = vi;
-      break;
-    }
-  }
-
   // Determine what items to draw (using visible indices)
   size_t first_visible_idx = 0;
   size_t last_visible_idx = visible_indices.size() - 1;
 
   if (number_items_fit_to_screen <= 1) {
     // If only one item can fit to the bounds draw the current cursor item
-    last_visible_idx = std::min(last_visible_idx, cursor_visible_index + 1);
-    first_visible_idx = cursor_visible_index;
+    last_visible_idx = std::min(last_visible_idx, cursor_visible_pos + 1);
+    first_visible_idx = cursor_visible_pos;
   } else {
     if (scroll_menu_items) {
       // Attempt to draw the item after the current item (+1 for equality check in the draw loop)
-      last_visible_idx = std::min(last_visible_idx, cursor_visible_index + 1);
+      last_visible_idx = std::min(last_visible_idx, cursor_visible_pos + 1);
 
       // Go back through the measurements to determine how many prior items we can fit
       int height_left_to_use = bounds->h;
@@ -191,7 +189,7 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
       }
       const size_t items_to_draw = last_visible_idx - first_visible_idx;
       // Don't draw last item partially if it is the selected item
-      if ((cursor_visible_index == last_visible_idx) &&
+      if ((cursor_visible_pos == last_visible_idx) &&
           (static_cast<size_t>(number_items_fit_to_screen) <= items_to_draw) &&
           (first_visible_idx < visible_indices.size() - 1)) {
         first_visible_idx++;

--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -92,6 +92,7 @@ void GraphicalDisplayMenu::on_before_hide() {
 }
 
 void GraphicalDisplayMenu::draw_and_update() {
+  this->ensure_cursor_visible_();
   this->update();
 
   // If we're in advanced drawing mode we won't have a display and will instead require the update callback to do

--- a/esphome/components/graphical_display_menu/graphical_display_menu.cpp
+++ b/esphome/components/graphical_display_menu/graphical_display_menu.cpp
@@ -54,9 +54,9 @@ void GraphicalDisplayMenu::dump_config() {
                 this->mode_ == display_menu_base::MENU_MODE_ROTARY ? "Rotary" : "Joystick", YESNO(this->active_));
   for (size_t i = 0; i < this->displayed_item_->items_size(); i++) {
     auto *item = this->displayed_item_->get_item(i);
-    ESP_LOGCONFIG(TAG, "  %i: %s (Type: %s, Immediate Edit: %s)", i, item->get_text().c_str(),
+    ESP_LOGCONFIG(TAG, "  %i: %s (Type: %s, Immediate Edit: %s, Visible: %s)", i, item->get_text().c_str(),
                   LOG_STR_ARG(display_menu_base::menu_item_type_to_string(item->get_type())),
-                  YESNO(item->get_immediate_edit()));
+                  YESNO(item->get_immediate_edit()), YESNO(item->is_visible()));
   }
 }
 
@@ -120,16 +120,25 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
   int y_padding = 2;
   bool scroll_menu_items = false;
   std::vector<display::Rect> menu_dimensions;
+  std::vector<size_t> visible_indices;
   int number_items_fit_to_screen = 0;
   const int max_item_index = this->displayed_item_->items_size() - 1;
 
+  // First pass: measure only visible items and collect their indices
+  bool first_visible = true;
   for (size_t i = 0; max_item_index >= 0 && i <= static_cast<size_t>(max_item_index); i++) {
     const auto *item = this->displayed_item_->get_item(i);
+    if (!item->is_visible()) {
+      continue;
+    }
+
+    visible_indices.push_back(i);
     const bool selected = i == this->cursor_index_;
     const display::Rect item_dimensions = this->measure_item(display, item, bounds, selected);
 
     menu_dimensions.push_back(item_dimensions);
-    total_height += item_dimensions.h + (i == 0 ? 0 : y_padding);
+    total_height += item_dimensions.h + (first_visible ? 0 : y_padding);
+    first_visible = false;
     max_width = std::max(max_width, item_dimensions.w);
 
     if (total_height <= bounds->h) {
@@ -142,36 +151,50 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
     }
   }
 
-  // Determine what items to draw
-  int first_item_index = 0;
-  int last_item_index = max_item_index;
+  if (visible_indices.empty()) {
+    return;
+  }
+
+  // Find cursor position in visible indices
+  size_t cursor_visible_index = 0;
+  for (size_t vi = 0; vi < visible_indices.size(); vi++) {
+    if (visible_indices[vi] == this->cursor_index_) {
+      cursor_visible_index = vi;
+      break;
+    }
+  }
+
+  // Determine what items to draw (using visible indices)
+  size_t first_visible_idx = 0;
+  size_t last_visible_idx = visible_indices.size() - 1;
 
   if (number_items_fit_to_screen <= 1) {
     // If only one item can fit to the bounds draw the current cursor item
-    last_item_index = std::min(last_item_index, this->cursor_index_ + 1);
-    first_item_index = this->cursor_index_;
+    last_visible_idx = std::min(last_visible_idx, cursor_visible_index + 1);
+    first_visible_idx = cursor_visible_index;
   } else {
     if (scroll_menu_items) {
       // Attempt to draw the item after the current item (+1 for equality check in the draw loop)
-      last_item_index = std::min(last_item_index, this->cursor_index_ + 1);
+      last_visible_idx = std::min(last_visible_idx, cursor_visible_index + 1);
 
       // Go back through the measurements to determine how many prior items we can fit
       int height_left_to_use = bounds->h;
-      for (int i = last_item_index; i >= 0; i--) {
-        const display::Rect item_dimensions = menu_dimensions[i];
+      for (int vi = static_cast<int>(last_visible_idx); vi >= 0; vi--) {
+        const display::Rect item_dimensions = menu_dimensions[vi];
         height_left_to_use -= (item_dimensions.h + y_padding);
 
         if (height_left_to_use <= 0) {
-          // Ran out of space -  this is our first item to draw
-          first_item_index = i;
+          // Ran out of space - this is our first item to draw
+          first_visible_idx = vi;
           break;
         }
       }
-      const int items_to_draw = last_item_index - first_item_index;
-      // Dont't draw last item partially if it is the selected item
-      if ((this->cursor_index_ == last_item_index) && (number_items_fit_to_screen <= items_to_draw) &&
-          (first_item_index < max_item_index)) {
-        first_item_index++;
+      const size_t items_to_draw = last_visible_idx - first_visible_idx;
+      // Don't draw last item partially if it is the selected item
+      if ((cursor_visible_index == last_visible_idx) &&
+          (static_cast<size_t>(number_items_fit_to_screen) <= items_to_draw) &&
+          (first_visible_idx < visible_indices.size() - 1)) {
+        first_visible_idx++;
       }
     }
   }
@@ -181,11 +204,11 @@ void GraphicalDisplayMenu::draw_menu_internal_(display::Display *display, const 
 
   display->filled_rectangle(bounds->x, bounds->y, max_width, total_height, this->background_color_);
   auto y_offset = bounds->y;
-  for (size_t i = static_cast<size_t>(first_item_index);
-       last_item_index >= 0 && i <= static_cast<size_t>(last_item_index); i++) {
-    const auto *item = this->displayed_item_->get_item(i);
-    const bool selected = i == this->cursor_index_;
-    display::Rect dimensions = menu_dimensions[i];
+  for (size_t vi = first_visible_idx; vi <= last_visible_idx; vi++) {
+    size_t item_index = visible_indices[vi];
+    const auto *item = this->displayed_item_->get_item(item_index);
+    const bool selected = item_index == this->cursor_index_;
+    display::Rect dimensions = menu_dimensions[vi];
 
     dimensions.y = y_offset;
     dimensions.x = bounds->x;


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core menu navigation and rendering to skip hidden items and keep the cursor in-bounds/visible; this may affect selection/scroll behavior in edge cases (e.g., all items hidden or dynamic visibility changes).
> 
> **Overview**
> Adds per-menu-item visibility support via a new `visible` config option (default `true`) and a new automation action `display_menu_item.set_visible` to toggle it at runtime.
> 
> Updates menu runtime behavior to *skip hidden items* when drawing and moving the cursor, including new helpers to find the next/previous/first visible item and ensuring the cursor/top index remain valid when entering/leaving or regenerating menus. Graphical menu rendering now measures/draws only visible items and logs include the visibility state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed06f8745e11c5f65cead5500c9403dc0767d6bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->