### PR TITLE
[JXD-393] Disable auth for captive portal

### DIFF
--- a/esphome/components/captive_portal/captive_portal.cpp
+++ b/esphome/components/captive_portal/captive_portal.cpp
@@ -62,7 +62,7 @@ void CaptivePortal::setup() {
 void CaptivePortal::start() {
   this->base_->init();
   if (!this->initialized_) {
-    this->base_->add_handler(this);
+    this->base_->add_handler(this, false);  // No auth for captive portal
   }
 
   network::IPAddress ip = wifi::global_wifi_component->wifi_soft_ap_ip();

--- a/esphome/components/web_server_base/web_server_base.cpp
+++ b/esphome/components/web_server_base/web_server_base.cpp
@@ -11,11 +11,9 @@ static const char *const TAG = "web_server_base";
 
 WebServerBase *global_web_server_base = nullptr;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)
 
-void WebServerBase::add_handler(AsyncWebHandler *handler) {
-  // remove all handlers
-
+void WebServerBase::add_handler(AsyncWebHandler *handler, bool add_auth) {
 #ifdef USE_WEBSERVER_AUTH
-  if (!credentials_.username.empty()) {
+  if (add_auth && !credentials_.username.empty()) {
     handler = new internal::AuthMiddlewareHandler(handler, &credentials_);
   }
 #endif

--- a/esphome/components/web_server_base/web_server_base.h
+++ b/esphome/components/web_server_base/web_server_base.h
@@ -135,7 +135,7 @@ class WebServerBase : public Component {
   void set_auth_password(std::string auth_password) { credentials_.password = std::move(auth_password); }
 #endif
 
-  void add_handler(AsyncWebHandler *handler);
+  void add_handler(AsyncWebHandler *handler, bool add_auth = true);
 
   void set_port(uint16_t port) { port_ = port; }
   uint16_t get_port() const { return port_; }


### PR DESCRIPTION
# What does this implement/fix?

<!-- Quick description and explanation of changes -->

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes request authentication behavior by allowing specific handlers (captive portal) to bypass `USE_WEBSERVER_AUTH`, which could unintentionally expose endpoints if misused. Scope is small and defaults preserve current behavior for existing handlers.
> 
> **Overview**
> The web server base now supports registering handlers with optional authentication via `WebServerBase::add_handler(handler, add_auth)` (defaulting to the previous behavior).
> 
> The captive portal registers its handler with `add_auth=false`, ensuring the portal UI and Wi‑Fi provisioning endpoints remain reachable even when web server auth is configured.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 63a62987cbe59baca5fd8a1c74ddd46001ae13f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->