### PR TITLE
[JXD-390] Workflow with generated files

### DIFF
--- a/esphome/__main__.py
+++ b/esphome/__main__.py
@@ -814,6 +814,7 @@ def command_version(args: ArgsProtocol) -> int | None:
 def command_clean(args: ArgsProtocol, config: ConfigType) -> int | None:
     try:
         writer.clean_build()
+        writer.clean_generated()
     except OSError as err:
         _LOGGER.error("Error deleting build files: %s", err)
         return 1

--- a/esphome/core/__init__.py
+++ b/esphome/core/__init__.py
@@ -703,6 +703,9 @@ class EsphomeCore:
     def relative_src_path(self, *path: str | Path) -> Path:
         return self.relative_build_path("src", *path)
 
+    def relative_generated_path(self, *path: str | Path) -> Path:
+        return self.relative_src_path("generated", *path)
+
     def relative_pioenvs_path(self, *path: str | Path) -> Path:
         return self.relative_build_path(".pioenvs", *path)
 

--- a/esphome/writer.py
+++ b/esphome/writer.py
@@ -119,12 +119,18 @@ def update_storage_json() -> None:
                 "Components removed (%s), cleaning build files...",
                 ", ".join(sorted(removed)),
             )
+            clean_generated_for_removed_components(removed)
         else:
             _LOGGER.info("Core config or version changed, cleaning build files...")
         clean_build()
     elif storage_should_update_cmake_cache(old, new):
         _LOGGER.info("Integrations changed, cleaning cmake cache...")
         clean_cmake_cache()
+        # Clean generated folders for removed components
+        if old is not None:
+            removed = old.loaded_integrations - new.loaded_integrations
+            if removed:
+                clean_generated_for_removed_components(removed)
 
     new.save(path)
 
@@ -299,6 +305,30 @@ def clean_cmake_cache():
         if pioenvs_cmake_path.is_file():
             _LOGGER.info("Deleting %s", pioenvs_cmake_path)
             pioenvs_cmake_path.unlink()
+
+
+def clean_generated():
+    """Clean the entire generated folder (codegen output files)."""
+    import shutil
+
+    generated = CORE.relative_generated_path()
+    if generated.is_dir():
+        _LOGGER.info("Deleting %s", generated)
+        shutil.rmtree(generated)
+
+
+def clean_generated_for_removed_components(removed_components: set[str]):
+    """Clean generated folders for removed components only."""
+    import shutil
+
+    generated = CORE.relative_generated_path()
+    if not generated.is_dir():
+        return
+
+    for subdir in generated.iterdir():
+        if subdir.is_dir() and subdir.name in removed_components:
+            _LOGGER.info("Deleting generated files for removed component: %s", subdir)
+            shutil.rmtree(subdir)
 
 
 def clean_build():


### PR DESCRIPTION
# What does this implement/fix?

Some components can generate cpp files. PR add support workflow for generated folder

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Other

**Related issue or feature (if applicable):**

- fixes <link to issue>

**Pull request in [esphome-docs](https://github.com/esphome/esphome-docs) with documentation (if applicable):**

- esphome/esphome-docs#<esphome-docs PR number goes here>

## Test Environment

- [ ] ESP32
- [ ] ESP32 IDF
- [ ] ESP8266
- [ ] RP2040
- [ ] BK72xx
- [ ] RTL87xx
- [ ] nRF52840

## Example entry for `config.yaml`:

```yaml
# Example config.yaml

```

## Checklist:
  - [ ] The code change is tested and works locally.
  - [ ] Tests have been added to verify that the new code works (under `tests/` folder).

If user exposed functionality or configuration variables are added/changed:
  - [ ] Documentation added/updated in [esphome-docs](https://github.com/esphome/esphome-docs).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds deletion of build-artifact `src/generated` output during clean and when components are removed; risk is limited to potentially removing expected-to-be-regenerated files under the build directory.
> 
> **Overview**
> Adds first-class support for a build `src/generated` folder used for component-generated C++ output.
> 
> `esphome clean` now also deletes the entire generated output directory, and storage/update logic additionally prunes per-component generated subfolders when integrations are removed (including during ESP-IDF CMake cache refresh).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit caf56d4f6d073d4f38c0bbccf5fbbfc65d8a89a9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->