### PR TITLE
Subscriber pattern for automation classes, binary_sensor, sensor, switch, time, some base trigger

### DIFF
--- a/esphome/components/binary_sensor/automation.h
+++ b/esphome/components/binary_sensor/automation.h
@@ -119,6 +119,10 @@ class MultiClickTrigger : public Trigger<>, public Component {
   ~MultiClickTrigger() override { this->parent_->remove_on_state_callback(this->handle_); }
 
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
+  bool prepare_for_deletion() override {
+    this->disable_loop();
+    return false;  // registered in Application, not safe to delete
+  }
 
   void set_invalid_cooldown(uint32_t invalid_cooldown) { this->invalid_cooldown_ = invalid_cooldown; }
 

--- a/esphome/components/binary_sensor/automation.h
+++ b/esphome/components/binary_sensor/automation.h
@@ -20,22 +20,32 @@ struct MultiClickTriggerEvent {
 
 class PressTrigger : public Trigger<> {
  public:
-  explicit PressTrigger(BinarySensor *parent) {
-    parent->add_on_state_callback([this](bool state) {
+  explicit PressTrigger(BinarySensor *parent) : parent_(parent) {
+    this->handle_ = parent->add_on_state_callback([this](bool state) {
       if (state)
         this->trigger();
     });
   }
+  ~PressTrigger() override { this->parent_->remove_on_state_callback(this->handle_); }
+
+ protected:
+  BinarySensor *parent_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
 };
 
 class ReleaseTrigger : public Trigger<> {
  public:
-  explicit ReleaseTrigger(BinarySensor *parent) {
-    parent->add_on_state_callback([this](bool state) {
+  explicit ReleaseTrigger(BinarySensor *parent) : parent_(parent) {
+    this->handle_ = parent->add_on_state_callback([this](bool state) {
       if (!state)
         this->trigger();
     });
   }
+  ~ReleaseTrigger() override { this->parent_->remove_on_state_callback(this->handle_); }
+
+ protected:
+  BinarySensor *parent_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
 };
 
 bool match_interval(uint32_t min_length, uint32_t max_length, uint32_t length);
@@ -43,8 +53,8 @@ bool match_interval(uint32_t min_length, uint32_t max_length, uint32_t length);
 class ClickTrigger : public Trigger<> {
  public:
   explicit ClickTrigger(BinarySensor *parent, uint32_t min_length, uint32_t max_length)
-      : min_length_(min_length), max_length_(max_length) {
-    parent->add_on_state_callback([this](bool state) {
+      : parent_(parent), min_length_(min_length), max_length_(max_length) {
+    this->handle_ = parent->add_on_state_callback([this](bool state) {
       if (state) {
         this->start_time_ = millis();
       } else {
@@ -54,8 +64,11 @@ class ClickTrigger : public Trigger<> {
       }
     });
   }
+  ~ClickTrigger() override { this->parent_->remove_on_state_callback(this->handle_); }
 
  protected:
+  BinarySensor *parent_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
   uint32_t start_time_{0};  /// The millis() time when the click started.
   uint32_t min_length_;     /// Minimum length of click. 0 means no minimum.
   uint32_t max_length_;     /// Maximum length of click. 0 means no maximum.
@@ -64,8 +77,8 @@ class ClickTrigger : public Trigger<> {
 class DoubleClickTrigger : public Trigger<> {
  public:
   explicit DoubleClickTrigger(BinarySensor *parent, uint32_t min_length, uint32_t max_length)
-      : min_length_(min_length), max_length_(max_length) {
-    parent->add_on_state_callback([this](bool state) {
+      : parent_(parent), min_length_(min_length), max_length_(max_length) {
+    this->handle_ = parent->add_on_state_callback([this](bool state) {
       const uint32_t now = millis();
 
       if (state && this->start_time_ != 0 && this->end_time_ != 0) {
@@ -82,8 +95,11 @@ class DoubleClickTrigger : public Trigger<> {
       this->end_time_ = now;
     });
   }
+  ~DoubleClickTrigger() override { this->parent_->remove_on_state_callback(this->handle_); }
 
  protected:
+  BinarySensor *parent_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
   uint32_t start_time_{0};
   uint32_t end_time_{0};
   uint32_t min_length_;  /// Minimum length of click. 0 means no minimum.
@@ -98,8 +114,9 @@ class MultiClickTrigger : public Trigger<>, public Component {
   void setup() override {
     this->last_state_ = this->parent_->get_state_default(false);
     auto f = std::bind(&MultiClickTrigger::on_state_, this, std::placeholders::_1);
-    this->parent_->add_on_state_callback(f);
+    this->handle_ = this->parent_->add_on_state_callback(f);
   }
+  ~MultiClickTrigger() override { this->parent_->remove_on_state_callback(this->handle_); }
 
   float get_setup_priority() const override { return setup_priority::HARDWARE; }
 
@@ -115,6 +132,7 @@ class MultiClickTrigger : public Trigger<>, public Component {
   void trigger_();
 
   BinarySensor *parent_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
   std::vector<MultiClickTriggerEvent> timing_;
   uint32_t invalid_cooldown_{1000};
   optional<size_t> at_index_{};
@@ -125,17 +143,27 @@ class MultiClickTrigger : public Trigger<>, public Component {
 
 class StateTrigger : public Trigger<bool> {
  public:
-  explicit StateTrigger(BinarySensor *parent) {
-    parent->add_on_state_callback([this](bool state) { this->trigger(state); });
+  explicit StateTrigger(BinarySensor *parent) : parent_(parent) {
+    this->handle_ = parent->add_on_state_callback([this](bool state) { this->trigger(state); });
   }
+  ~StateTrigger() override { this->parent_->remove_on_state_callback(this->handle_); }
+
+ protected:
+  BinarySensor *parent_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
 };
 
 class StateChangeTrigger : public Trigger<optional<bool>, optional<bool> > {
  public:
-  explicit StateChangeTrigger(BinarySensor *parent) {
-    parent->add_full_state_callback(
+  explicit StateChangeTrigger(BinarySensor *parent) : parent_(parent) {
+    this->handle_ = parent->add_full_state_callback(
         [this](optional<bool> old_state, optional<bool> state) { this->trigger(old_state, state); });
   }
+  ~StateChangeTrigger() override { this->parent_->remove_full_state_callback(this->handle_); }
+
+ protected:
+  BinarySensor *parent_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
 };
 
 template<typename... Ts> class BinarySensorCondition : public Condition<Ts...> {

--- a/esphome/components/sensor/sensor.cpp
+++ b/esphome/components/sensor/sensor.cpp
@@ -85,7 +85,10 @@ void Sensor::publish_state(float state) {
   }
 }
 
-void Sensor::add_on_state_callback(std::function<void(float)> &&callback) { this->callback_.add(std::move(callback)); }
+CallbackHandle Sensor::add_on_state_callback(std::function<void(float)> &&callback) {
+  return this->callback_.add(std::move(callback));
+}
+void Sensor::remove_on_state_callback(CallbackHandle handle) { this->callback_.remove(handle); }
 void Sensor::add_on_raw_state_callback(std::function<void(float)> &&callback) {
   if (!this->raw_callback_) {
     this->raw_callback_ = make_unique<CallbackManager<void(float)>>();

--- a/esphome/components/sensor/sensor.h
+++ b/esphome/components/sensor/sensor.h
@@ -122,8 +122,10 @@ class Sensor : public EntityBase, public EntityBase_DeviceClass, public EntityBa
 
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
-  /// Add a callback that will be called every time a filtered value arrives.
-  void add_on_state_callback(std::function<void(float)> &&callback);
+  /// Add a callback that will be called every time a filtered value arrives. Returns a handle for removal.
+  CallbackHandle add_on_state_callback(std::function<void(float)> &&callback);
+  /// Remove a previously registered state callback by handle.
+  void remove_on_state_callback(CallbackHandle handle);
   /// Add a callback that will be called every time the sensor sends a raw value.
   void add_on_raw_state_callback(std::function<void(float)> &&callback);
 

--- a/esphome/components/switch/automation.h
+++ b/esphome/components/switch/automation.h
@@ -66,31 +66,46 @@ template<typename... Ts> class SwitchCondition : public Condition<Ts...> {
 
 class SwitchStateTrigger : public Trigger<bool> {
  public:
-  SwitchStateTrigger(Switch *a_switch) {
-    a_switch->add_on_state_callback([this](bool state) { this->trigger(state); });
+  SwitchStateTrigger(Switch *a_switch) : switch_(a_switch) {
+    this->handle_ = a_switch->add_on_state_callback([this](bool state) { this->trigger(state); });
   }
+  ~SwitchStateTrigger() override { this->switch_->remove_on_state_callback(this->handle_); }
+
+ protected:
+  Switch *switch_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
 };
 
 class SwitchTurnOnTrigger : public Trigger<> {
  public:
-  SwitchTurnOnTrigger(Switch *a_switch) {
-    a_switch->add_on_state_callback([this](bool state) {
+  SwitchTurnOnTrigger(Switch *a_switch) : switch_(a_switch) {
+    this->handle_ = a_switch->add_on_state_callback([this](bool state) {
       if (state) {
         this->trigger();
       }
     });
   }
+  ~SwitchTurnOnTrigger() override { this->switch_->remove_on_state_callback(this->handle_); }
+
+ protected:
+  Switch *switch_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
 };
 
 class SwitchTurnOffTrigger : public Trigger<> {
  public:
-  SwitchTurnOffTrigger(Switch *a_switch) {
-    a_switch->add_on_state_callback([this](bool state) {
+  SwitchTurnOffTrigger(Switch *a_switch) : switch_(a_switch) {
+    this->handle_ = a_switch->add_on_state_callback([this](bool state) {
       if (!state) {
         this->trigger();
       }
     });
   }
+  ~SwitchTurnOffTrigger() override { this->switch_->remove_on_state_callback(this->handle_); }
+
+ protected:
+  Switch *switch_;
+  CallbackHandle handle_{CALLBACK_HANDLE_INVALID};
 };
 
 template<typename... Ts> class SwitchPublishAction : public Action<Ts...> {

--- a/esphome/components/switch/switch.cpp
+++ b/esphome/components/switch/switch.cpp
@@ -78,9 +78,10 @@ void Switch::publish_state(bool state) {
 }
 bool Switch::assumed_state() { return false; }
 
-void Switch::add_on_state_callback(std::function<void(bool)> &&callback) {
-  this->state_callback_.add(std::move(callback));
+CallbackHandle Switch::add_on_state_callback(std::function<void(bool)> &&callback) {
+  return this->state_callback_.add(std::move(callback));
 }
+void Switch::remove_on_state_callback(CallbackHandle handle) { this->state_callback_.remove(handle); }
 void Switch::set_inverted(bool inverted) { this->inverted_ = inverted; }
 bool Switch::is_inverted() const { return this->inverted_; }
 

--- a/esphome/components/switch/switch.h
+++ b/esphome/components/switch/switch.h
@@ -93,8 +93,15 @@ class Switch : public EntityBase, public EntityBase_DeviceClass {
   /** Set callback for state changes.
    *
    * @param callback The void(bool) callback.
+   * @return A handle that can be used to remove the callback later.
    */
-  void add_on_state_callback(std::function<void(bool)> &&callback);
+  CallbackHandle add_on_state_callback(std::function<void(bool)> &&callback);
+
+  /** Remove a previously registered state callback.
+   *
+   * @param handle The handle returned by add_on_state_callback.
+   */
+  void remove_on_state_callback(CallbackHandle handle);
 
   /** Returns the initial state of the switch, as persisted previously,
     or empty if never persisted.

--- a/esphome/components/time/automation.h
+++ b/esphome/components/time/automation.h
@@ -29,6 +29,10 @@ class CronTrigger : public Trigger<>, public Component {
   bool matches(const ESPTime &time);
   void loop() override;
   float get_setup_priority() const override;
+  bool prepare_for_deletion() override {
+    this->disable_loop();
+    return false;  // registered in Application, not safe to delete
+  }
 
  protected:
   std::bitset<61> seconds_;

--- a/esphome/core/automation.h
+++ b/esphome/core/automation.h
@@ -141,6 +141,13 @@ template<typename... Ts> class Automation;
 
 template<typename... Ts> class Trigger {
  public:
+  virtual ~Trigger() = default;
+
+  /// Called before deletion to allow cleanup (e.g. disable_loop() for Component-based triggers).
+  /// Returns true if the trigger can be safely deleted, false if it must remain alive
+  /// (e.g. Component-based triggers that are registered in Application::components_).
+  virtual bool prepare_for_deletion() { return true; }
+
   /// Inform the parent automation that the event has triggered.
   void trigger(Ts... x) {
     if (this->automation_parent_ == nullptr)
@@ -285,8 +292,33 @@ template<typename... Ts> class Automation {
  public:
   explicit Automation(Trigger<Ts...> *trigger) : trigger_(trigger) { this->trigger_->set_automation_parent(this); }
 
+  ~Automation() {
+    if (this->owns_triggers_) {
+      for (auto *t : this->additional_triggers_) {
+        if (t->prepare_for_deletion()) {
+          delete t;
+        } else {
+          // Component-based trigger: can't delete (Application holds pointer),
+          // just neutralize so it won't fire into destroyed automation
+          t->set_automation_parent(nullptr);
+        }
+      }
+      if (this->trigger_->prepare_for_deletion()) {
+        delete this->trigger_;
+      } else {
+        this->trigger_->set_automation_parent(nullptr);
+      }
+    }
+  }
+
   void add_action(Action<Ts...> *action) { this->actions_.add_action(action); }
   void add_actions(const std::vector<Action<Ts...> *> &actions) { this->actions_.add_actions(actions); }
+
+  /// Add an additional trigger to this automation (sets automation_parent automatically).
+  void add_trigger(Trigger<Ts...> *trigger) {
+    trigger->set_automation_parent(this);
+    this->additional_triggers_.push_back(trigger);
+  }
 
   void stop() { this->actions_.stop(); }
 
@@ -304,9 +336,14 @@ template<typename... Ts> class Automation {
 
   void set_enabled(bool val) { this->enabled_ = val; }
 
+  /// Set whether this automation owns its triggers and should delete them on destruction.
+  void set_owns_triggers(bool owns) { this->owns_triggers_ = owns; }
+
  protected:
   bool enabled_{true};
+  bool owns_triggers_{false};
   Trigger<Ts...> *trigger_;
+  std::vector<Trigger<Ts...> *> additional_triggers_;
   ActionList<Ts...> actions_;
 };
 

--- a/esphome/core/base_automation.h
+++ b/esphome/core/base_automation.h
@@ -109,6 +109,10 @@ class StartupTrigger : public Trigger<>, public Component {
   explicit StartupTrigger(float setup_priority) : setup_priority_(setup_priority) {}
   void setup() override { this->trigger(); }
   float get_setup_priority() const override { return this->setup_priority_; }
+  bool prepare_for_deletion() override {
+    this->disable_loop();
+    return false;  // registered in Application, not safe to delete
+  }
 
  protected:
   float setup_priority_;
@@ -119,6 +123,10 @@ class ShutdownTrigger : public Trigger<>, public Component {
   explicit ShutdownTrigger(float setup_priority) : setup_priority_(setup_priority) {}
   void on_shutdown() override { this->trigger(); }
   float get_setup_priority() const override { return this->setup_priority_; }
+  bool prepare_for_deletion() override {
+    this->disable_loop();
+    return false;  // registered in Application, not safe to delete
+  }
 
  protected:
   float setup_priority_;
@@ -128,6 +136,10 @@ class LoopTrigger : public Trigger<>, public Component {
  public:
   void loop() override { this->trigger(); }
   float get_setup_priority() const override { return setup_priority::DATA; }
+  bool prepare_for_deletion() override {
+    this->disable_loop();
+    return false;  // registered in Application, not safe to delete
+  }
 };
 
 #ifdef ESPHOME_PROJECT_NAME

--- a/esphome/core/entity_base.h
+++ b/esphome/core/entity_base.h
@@ -220,15 +220,23 @@ template<typename T> class StatefulEntityBase : public EntityBase {
   virtual T get_state_default(T default_value) const { return this->state_.value_or(default_value); }
   void invalidate_state() { this->set_state_({}); }
 
-  void add_full_state_callback(std::function<void(optional<T> previous, optional<T> current)> &&callback) {
+  CallbackHandle add_full_state_callback(std::function<void(optional<T> previous, optional<T> current)> &&callback) {
     if (this->full_state_callbacks_ == nullptr)
       this->full_state_callbacks_ = new CallbackManager<void(optional<T> previous, optional<T> current)>();  // NOLINT
-    this->full_state_callbacks_->add(std::move(callback));
+    return this->full_state_callbacks_->add(std::move(callback));
   }
-  void add_on_state_callback(std::function<void(T)> &&callback) {
+  void remove_full_state_callback(CallbackHandle handle) {
+    if (this->full_state_callbacks_ != nullptr)
+      this->full_state_callbacks_->remove(handle);
+  }
+  CallbackHandle add_on_state_callback(std::function<void(T)> &&callback) {
     if (this->state_callbacks_ == nullptr)
       this->state_callbacks_ = new CallbackManager<void(T)>();  // NOLINT
-    this->state_callbacks_->add(std::move(callback));
+    return this->state_callbacks_->add(std::move(callback));
+  }
+  void remove_on_state_callback(CallbackHandle handle) {
+    if (this->state_callbacks_ != nullptr)
+      this->state_callbacks_->remove(handle);
   }
 
   void set_trigger_on_initial_state(bool trigger_on_initial_state) {

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -674,25 +674,51 @@ constexpr float fahrenheit_to_celsius(float value) { return (value - 32.0f) / 1.
 /// @name Utilities
 /// @{
 
+/// Handle returned by CallbackManager::add() for later removal via remove().
+using CallbackHandle = uint32_t;
+/// Sentinel value indicating an invalid or uninitialized callback handle.
+static constexpr CallbackHandle CALLBACK_HANDLE_INVALID = UINT32_MAX;
+
 template<typename... X> class CallbackManager;
 
 /** Helper class to allow having multiple subscribers to a callback.
+ *
+ * Supports subscribe/unsubscribe via CallbackHandle. Removed slots are nullified
+ * and skipped during call(). No compaction is performed -- slot count per entity is typically small.
  *
  * @tparam Ts The arguments for the callbacks, wrapped in void().
  */
 template<typename... Ts> class CallbackManager<void(Ts...)> {
  public:
-  /// Add a callback to the list.
-  void add(std::function<void(Ts...)> &&callback) { this->callbacks_.push_back(std::move(callback)); }
+  /// Add a callback to the list. Returns a handle that can be used to remove it later.
+  CallbackHandle add(std::function<void(Ts...)> &&callback) {
+    // Reuse a null slot if available
+    for (uint32_t i = 0; i < this->callbacks_.size(); i++) {
+      if (!this->callbacks_[i]) {
+        this->callbacks_[i] = std::move(callback);
+        return i;
+      }
+    }
+    this->callbacks_.push_back(std::move(callback));
+    return static_cast<CallbackHandle>(this->callbacks_.size() - 1);
+  }
 
-  /// Call all callbacks in this manager.
+  /// Remove a callback by handle (nullifies the slot).
+  void remove(CallbackHandle handle) {
+    if (handle < this->callbacks_.size()) {
+      this->callbacks_[handle] = nullptr;
+    }
+  }
+
+  /// Call all active callbacks in this manager (skips removed/null slots).
   void call(Ts... args) {
     for (auto &cb : this->callbacks_)
-      cb(args...);
+      if (cb)
+        cb(args...);
   }
   size_t size() const { return this->callbacks_.size(); }
 
-  /// Call all callbacks in this manager.
+  /// Call all active callbacks in this manager.
   void operator()(Ts... args) { call(args...); }
 
  protected:

--- a/esphome/core/helpers.h
+++ b/esphome/core/helpers.h
@@ -712,9 +712,11 @@ template<typename... Ts> class CallbackManager<void(Ts...)> {
 
   /// Call all active callbacks in this manager (skips removed/null slots).
   void call(Ts... args) {
-    for (auto &cb : this->callbacks_)
-      if (cb)
+    for (auto &cb : this->callbacks_) {
+      if (cb) {
         cb(args...);
+      }
+    }
   }
   size_t size() const { return this->callbacks_.size(); }
 


### PR DESCRIPTION
…

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core callback dispatch and automation trigger lifecycles; mistakes could cause missed events or dangling callbacks, though changes are localized and mostly additive.
> 
> **Overview**
> Introduces an unsubscribe-capable subscriber pattern across core entities by adding `CallbackHandle` support to `CallbackManager` and exposing `add_*_callback()` methods that return handles plus new `remove_*_callback()` APIs (notably for `Sensor`, `Switch`, and `StatefulEntityBase`).
> 
> Updates automation triggers for `binary_sensor` and `switch` to store callback handles and unregister in destructors, and adds `Trigger::prepare_for_deletion()` plus `Automation` trigger ownership/cleanup (`set_owns_triggers()`, `add_trigger()`) so automations can safely tear down or neutralize triggers that can’t be deleted (Component-registered triggers like `MultiClickTrigger`, `CronTrigger`, and base `Startup`/`Shutdown`/`Loop` triggers now disable looping on deletion prep).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ed9774fbc4ac58bb69d4c54f7973241cd785216. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->