### PR TITLE
Set callback for saving wifi_sta

### DIFF
--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -335,7 +335,7 @@ void WiFiComponent::set_sta(const WiFiAP &ap) {
 }
 void WiFiComponent::clear_sta() { this->sta_.clear(); }
 void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &password) {
-#ifdef USE_NETWORK_SETTINGS_JSON
+#ifdef JETHOME_NETWORK_SETTINGS_SAVE
   if (this->wifi_save_handler_ != nullptr) {
     // Use external handler (e.g., config_json) for persistence
     this->wifi_save_handler_(ssid, password);
@@ -348,7 +348,7 @@ void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &pa
     this->pref_.save(&save);
     // ensure it's written immediately
     global_preferences->sync();
-#ifdef USE_NETWORK_SETTINGS_JSON
+#ifdef JETHOME_NETWORK_SETTINGS_SAVE
   }
 #endif
 

--- a/esphome/components/wifi/wifi_component.cpp
+++ b/esphome/components/wifi/wifi_component.cpp
@@ -335,13 +335,24 @@ void WiFiComponent::set_sta(const WiFiAP &ap) {
 }
 void WiFiComponent::clear_sta() { this->sta_.clear(); }
 void WiFiComponent::save_wifi_sta(const std::string &ssid, const std::string &password) {
-  SavedWifiSettings save{};  // zero-initialized - all bytes set to \0, guaranteeing null termination
-  strncpy(save.ssid, ssid.c_str(), sizeof(save.ssid) - 1);              // max 32 chars, byte 32 remains \0
-  strncpy(save.password, password.c_str(), sizeof(save.password) - 1);  // max 64 chars, byte 64 remains \0
-  this->pref_.save(&save);
-  // ensure it's written immediately
-  global_preferences->sync();
+#ifdef USE_NETWORK_SETTINGS_JSON
+  if (this->wifi_save_handler_ != nullptr) {
+    // Use external handler (e.g., config_json) for persistence
+    this->wifi_save_handler_(ssid, password);
+  } else {
+#endif
+    // Default: save to NVS preferences
+    SavedWifiSettings save{};  // zero-initialized - all bytes set to \0, guaranteeing null termination
+    strncpy(save.ssid, ssid.c_str(), sizeof(save.ssid) - 1);              // max 32 chars, byte 32 remains \0
+    strncpy(save.password, password.c_str(), sizeof(save.password) - 1);  // max 64 chars, byte 64 remains \0
+    this->pref_.save(&save);
+    // ensure it's written immediately
+    global_preferences->sync();
+#ifdef USE_NETWORK_SETTINGS_JSON
+  }
+#endif
 
+  // Always update in-memory state
   WiFiAP sta{};
   sta.set_ssid(ssid);
   sta.set_password(password);

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -253,7 +253,7 @@ class WiFiComponent : public Component {
 
   void save_wifi_sta(const std::string &ssid, const std::string &password);
 
-#ifdef USE_NETWORK_SETTINGS_JSON
+#ifdef JETHOME_NETWORK_SETTINGS_SAVE
   using WiFiSaveHandler = std::function<void(const std::string &, const std::string &)>;
   void set_wifi_save_handler(WiFiSaveHandler handler) { this->wifi_save_handler_ = std::move(handler); }
 #endif
@@ -436,7 +436,7 @@ class WiFiComponent : public Component {
   Trigger<> *connect_trigger_{new Trigger<>()};
   Trigger<> *disconnect_trigger_{new Trigger<>()};
 
-#ifdef USE_NETWORK_SETTINGS_JSON
+#ifdef JETHOME_NETWORK_SETTINGS_SAVE
   WiFiSaveHandler wifi_save_handler_{nullptr};
 #endif
 };

--- a/esphome/components/wifi/wifi_component.h
+++ b/esphome/components/wifi/wifi_component.h
@@ -7,6 +7,7 @@
 #include "esphome/core/component.h"
 #include "esphome/core/helpers.h"
 
+#include <functional>
 #include <string>
 #include <vector>
 
@@ -251,6 +252,12 @@ class WiFiComponent : public Component {
   void set_passive_scan(bool passive);
 
   void save_wifi_sta(const std::string &ssid, const std::string &password);
+
+#ifdef USE_NETWORK_SETTINGS_JSON
+  using WiFiSaveHandler = std::function<void(const std::string &, const std::string &)>;
+  void set_wifi_save_handler(WiFiSaveHandler handler) { this->wifi_save_handler_ = std::move(handler); }
+#endif
+
   // ========== INTERNAL METHODS ==========
   // (In most use cases you won't need these)
   /// Setup WiFi interface.
@@ -428,6 +435,10 @@ class WiFiComponent : public Component {
   // Pointers at the end (naturally aligned)
   Trigger<> *connect_trigger_{new Trigger<>()};
   Trigger<> *disconnect_trigger_{new Trigger<>()};
+
+#ifdef USE_NETWORK_SETTINGS_JSON
+  WiFiSaveHandler wifi_save_handler_{nullptr};
+#endif
 };
 
 extern WiFiComponent *global_wifi_component;  // NOLINT(cppcoreguidelines-avoid-non-const-global-variables)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches WiFi credential persistence; an incorrectly set/implemented external handler could prevent credentials from being saved across reboots, though the default NVS path remains unchanged.
> 
> **Overview**
> `WiFiComponent::save_wifi_sta` now conditionally delegates persistence of the SSID/password to a user-provided `wifi_save_handler_` (guarded by `JETHOME_NETWORK_SETTINGS_SAVE`), falling back to the existing NVS preference write when no handler is set.
> 
> The WiFi component header adds the `WiFiSaveHandler` type plus `set_wifi_save_handler()` and stores the handler, and `save_wifi_sta` is adjusted to **always** update the in-memory STA config regardless of which persistence path is used.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e148edd169cfd9c6f2effe9758d438d0aed0b7b3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->