### PR TITLE
[display_menu_base] Back n feature

### DIFF
--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -213,6 +213,28 @@ void DisplayMenuComponent::back() {
   }
 }
 
+void DisplayMenuComponent::back_n(int levels) {
+  if (this->check_healthy_and_active_() && levels > 0) {
+    if (this->editing_)
+      this->finish_editing_();
+
+    // Lightweight unwind for intermediate levels — skip regeneration and cursor fixes
+    for (int i = 0; i < levels - 1 && this->displayed_item_->get_parent() != nullptr; i++) {
+      this->displayed_item_->on_leave();
+      auto *item = this->displayed_item_;
+      if (item->get_type() == MENU_ITEM_MENU && static_cast<MenuItemMenu *>(item)->is_generate_on_enter()) {
+        static_cast<MenuItemMenu *>(item)->clear_items();
+      }
+      this->displayed_item_ = this->displayed_item_->get_parent();
+      this->selection_stack_.pop_front();
+    }
+
+    // Full leave for the final level — with regeneration and cursor adjustment
+    if (this->leave_menu_())
+      this->draw_and_update();
+  }
+}
+
 void DisplayMenuComponent::enter() {
   if (this->check_healthy_and_active_()) {
     bool changed = false;

--- a/esphome/components/display_menu_base/display_menu_base.cpp
+++ b/esphome/components/display_menu_base/display_menu_base.cpp
@@ -215,8 +215,12 @@ void DisplayMenuComponent::back() {
 
 void DisplayMenuComponent::back_n(int levels) {
   if (this->check_healthy_and_active_() && levels > 0) {
-    if (this->editing_)
+    bool changed = false;
+
+    if (this->editing_) {
       this->finish_editing_();
+      changed = true;
+    }
 
     // Lightweight unwind for intermediate levels — skip regeneration and cursor fixes
     for (int i = 0; i < levels - 1 && this->displayed_item_->get_parent() != nullptr; i++) {
@@ -227,10 +231,18 @@ void DisplayMenuComponent::back_n(int levels) {
       }
       this->displayed_item_ = this->displayed_item_->get_parent();
       this->selection_stack_.pop_front();
+      changed = true;
     }
 
-    // Full leave for the final level — with regeneration and cursor adjustment
-    if (this->leave_menu_())
+    if (this->displayed_item_->get_parent() != nullptr) {
+      // Full leave for the final level — with regeneration and cursor adjustment
+      changed = this->leave_menu_() || changed;
+    } else if (changed) {
+      // Already at root after intermediate unwind — fix stale cursor state
+      this->reset_();
+    }
+
+    if (changed)
       this->draw_and_update();
   }
 }

--- a/esphome/components/display_menu_base/display_menu_base.h
+++ b/esphome/components/display_menu_base/display_menu_base.h
@@ -43,6 +43,8 @@ class DisplayMenuComponent : public Component {
   void right();
   void enter();
   void back();
+  // Go back multiple levels at once
+  void back_n(int levels);
 
   // Go to root of menu and show it
   void show_main();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes menu navigation state transitions by allowing multi-level unwinds and manually manipulating `selection_stack_`/cursor state, which could surface edge cases when leaving generated menus or near the root.
> 
> **Overview**
> Adds `DisplayMenuComponent::back_n(int levels)` to navigate back multiple menu levels in one call.
> 
> The new logic finishes any active edit, unwinds intermediate levels by calling `on_leave()`, clearing generate-on-enter menus, and popping `selection_stack_`, then performs a final `leave_menu_()` (or `reset_()` if already at root) before redrawing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0b3dd9782a72627bf57805518834058e535c371f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->