### PR TITLE
MQTT topics refactor

### DIFF
--- a/esphome/components/mqtt/__init__.py
+++ b/esphome/components/mqtt/__init__.py
@@ -158,48 +158,35 @@ MQTT_DISCOVERY_OBJECT_ID_GENERATOR_OPTIONS = {
 def validate_config(value):
     # Populate default fields
     out = value.copy()
-    topic_prefix = value[CONF_TOPIC_PREFIX]
-    # If the topic prefix is not null and these messages are not configured, then set them to the default
-    # If the topic prefix is null and these messages are not configured, then set them to null
-    if CONF_BIRTH_MESSAGE not in value:
-        if topic_prefix != "":
+    topic_prefix = value.get(CONF_TOPIC_PREFIX)
+    if topic_prefix:
+        if CONF_BIRTH_MESSAGE not in value:
             out[CONF_BIRTH_MESSAGE] = {
                 CONF_TOPIC: f"{topic_prefix}/status",
                 CONF_PAYLOAD: "online",
                 CONF_QOS: 0,
                 CONF_RETAIN: True,
             }
-        else:
-            out[CONF_BIRTH_MESSAGE] = {}
-    if CONF_WILL_MESSAGE not in value:
-        if topic_prefix != "":
+        if CONF_WILL_MESSAGE not in value:
             out[CONF_WILL_MESSAGE] = {
                 CONF_TOPIC: f"{topic_prefix}/status",
                 CONF_PAYLOAD: "offline",
                 CONF_QOS: 0,
                 CONF_RETAIN: True,
             }
-        else:
-            out[CONF_WILL_MESSAGE] = {}
-    if CONF_SHUTDOWN_MESSAGE not in value:
-        if topic_prefix != "":
+        if CONF_SHUTDOWN_MESSAGE not in value:
             out[CONF_SHUTDOWN_MESSAGE] = {
                 CONF_TOPIC: f"{topic_prefix}/status",
                 CONF_PAYLOAD: "offline",
                 CONF_QOS: 0,
                 CONF_RETAIN: True,
             }
-        else:
-            out[CONF_SHUTDOWN_MESSAGE] = {}
-    if CONF_LOG_TOPIC not in value:
-        if topic_prefix != "":
+        if CONF_LOG_TOPIC not in value:
             out[CONF_LOG_TOPIC] = {
                 CONF_TOPIC: f"{topic_prefix}/debug",
                 CONF_QOS: 0,
                 CONF_RETAIN: True,
             }
-        else:
-            out[CONF_LOG_TOPIC] = {}
     return out
 
 
@@ -254,7 +241,7 @@ CONFIG_SCHEMA = cv.All(
             cv.Optional(CONF_BIRTH_MESSAGE): MQTT_MESSAGE_SCHEMA,
             cv.Optional(CONF_WILL_MESSAGE): MQTT_MESSAGE_SCHEMA,
             cv.Optional(CONF_SHUTDOWN_MESSAGE): MQTT_MESSAGE_SCHEMA,
-            cv.Optional(CONF_TOPIC_PREFIX, default=lambda: CORE.name): cv.publish_topic,
+            cv.Optional(CONF_TOPIC_PREFIX): cv.publish_topic,
             cv.Optional(CONF_LOG_TOPIC): cv.Any(
                 None,
                 MQTT_MESSAGE_BASE.extend(
@@ -376,35 +363,41 @@ async def to_code(config):
             )
         )
 
-    cg.add(var.set_topic_prefix(config[CONF_TOPIC_PREFIX], CORE.name))
+    if CONF_TOPIC_PREFIX in config:
+        cg.add(var.set_topic_prefix(config[CONF_TOPIC_PREFIX]))
 
     if config[CONF_USE_ABBREVIATIONS]:
         cg.add_define("USE_MQTT_ABBREVIATIONS")
 
-    birth_message = config[CONF_BIRTH_MESSAGE]
-    if not birth_message:
-        cg.add(var.disable_birth_message())
-    else:
-        cg.add(var.set_birth_message(exp_mqtt_message(birth_message)))
-    will_message = config[CONF_WILL_MESSAGE]
-    if not will_message:
-        cg.add(var.disable_last_will())
-    else:
-        cg.add(var.set_last_will(exp_mqtt_message(will_message)))
-    shutdown_message = config[CONF_SHUTDOWN_MESSAGE]
-    if not shutdown_message:
-        cg.add(var.disable_shutdown_message())
-    else:
-        cg.add(var.set_shutdown_message(exp_mqtt_message(shutdown_message)))
+    if CONF_BIRTH_MESSAGE in config:
+        birth_message = config[CONF_BIRTH_MESSAGE]
+        if birth_message:
+            cg.add(var.set_birth_message(exp_mqtt_message(birth_message)))
+        else:
+            cg.add(var.disable_birth_message())
 
-    log_topic = config[CONF_LOG_TOPIC]
-    if not log_topic:
-        cg.add(var.disable_log_message())
-    else:
-        cg.add(var.set_log_message_template(exp_mqtt_message(log_topic)))
+    if CONF_WILL_MESSAGE in config:
+        will_message = config[CONF_WILL_MESSAGE]
+        if will_message:
+            cg.add(var.set_last_will(exp_mqtt_message(will_message)))
+        else:
+            cg.add(var.disable_last_will())
 
-        if CONF_LEVEL in log_topic:
-            cg.add(var.set_log_level(logger.LOG_LEVELS[log_topic[CONF_LEVEL]]))
+    if CONF_SHUTDOWN_MESSAGE in config:
+        shutdown_message = config[CONF_SHUTDOWN_MESSAGE]
+        if shutdown_message:
+            cg.add(var.set_shutdown_message(exp_mqtt_message(shutdown_message)))
+        else:
+            cg.add(var.disable_shutdown_message())
+
+    if CONF_LOG_TOPIC in config:
+        log_topic = config[CONF_LOG_TOPIC]
+        if log_topic:
+            cg.add(var.set_log_message_template(exp_mqtt_message(log_topic)))
+            if CONF_LEVEL in log_topic:
+                cg.add(var.set_log_level(logger.LOG_LEVELS[log_topic[CONF_LEVEL]]))
+        else:
+            cg.add(var.disable_log_message())
 
     if CONF_SSL_FINGERPRINTS in config:
         for fingerprint in config[CONF_SSL_FINGERPRINTS]:

--- a/esphome/components/mqtt/mqtt_client.cpp
+++ b/esphome/components/mqtt/mqtt_client.cpp
@@ -34,6 +34,24 @@ MQTTClientComponent::MQTTClientComponent() {
 
 // Connection
 void MQTTClientComponent::setup() {
+  if (this->topic_prefix_auto_) {
+    this->topic_prefix_ = str_sanitize(App.get_name());
+  }
+  std::string status_topic = this->topic_prefix_ + "/status";
+  if (this->birth_message_auto_) {
+    this->birth_message_ = {.topic = status_topic, .payload = "online", .qos = 0, .retain = true};
+  }
+  if (this->last_will_auto_) {
+    this->last_will_ = {.topic = status_topic, .payload = "offline", .qos = 0, .retain = true};
+  }
+  if (this->shutdown_message_auto_) {
+    this->shutdown_message_ = {.topic = status_topic, .payload = "offline", .qos = 0, .retain = true};
+  }
+  if (this->log_message_auto_) {
+    this->log_message_ = {.topic = this->topic_prefix_ + "/debug", .payload = "", .qos = 0, .retain = true};
+  }
+  this->recalculate_availability_();
+
   this->mqtt_backend_.set_on_message(
       [this](const char *topic, const char *payload, size_t len, size_t index, size_t total) {
         if (index == 0)
@@ -618,20 +636,23 @@ void MQTTClientComponent::on_message(const std::string &topic, const std::string
 }
 
 // Setters
-void MQTTClientComponent::disable_log_message() { this->log_message_.topic = ""; }
+void MQTTClientComponent::disable_log_message() {
+  this->log_message_.topic = "";
+  this->log_message_auto_ = false;
+}
 bool MQTTClientComponent::is_log_message_enabled() const { return !this->log_message_.topic.empty(); }
 void MQTTClientComponent::set_reboot_timeout(uint32_t reboot_timeout) { this->reboot_timeout_ = reboot_timeout; }
 void MQTTClientComponent::register_mqtt_component(MQTTComponent *component) { this->children_.push_back(component); }
 void MQTTClientComponent::set_log_level(int level) { this->log_level_ = level; }
 void MQTTClientComponent::set_keep_alive(uint16_t keep_alive_s) { this->mqtt_backend_.set_keep_alive(keep_alive_s); }
-void MQTTClientComponent::set_log_message_template(MQTTMessage &&message) { this->log_message_ = std::move(message); }
+void MQTTClientComponent::set_log_message_template(MQTTMessage &&message) {
+  this->log_message_ = std::move(message);
+  this->log_message_auto_ = false;
+}
 const MQTTDiscoveryInfo &MQTTClientComponent::get_discovery_info() const { return this->discovery_info_; }
-void MQTTClientComponent::set_topic_prefix(const std::string &topic_prefix, const std::string &check_topic_prefix) {
-  if (App.is_name_add_mac_suffix_enabled() && (topic_prefix == check_topic_prefix)) {
-    this->topic_prefix_ = str_sanitize(App.get_name());
-  } else {
-    this->topic_prefix_ = topic_prefix;
-  }
+void MQTTClientComponent::set_topic_prefix(const std::string &topic_prefix) {
+  this->topic_prefix_ = topic_prefix;
+  this->topic_prefix_auto_ = false;
 }
 const std::string &MQTTClientComponent::get_topic_prefix() const { return this->topic_prefix_; }
 void MQTTClientComponent::set_publish_nan_as_none(bool publish_nan_as_none) {
@@ -640,10 +661,12 @@ void MQTTClientComponent::set_publish_nan_as_none(bool publish_nan_as_none) {
 bool MQTTClientComponent::is_publish_nan_as_none() const { return this->publish_nan_as_none_; }
 void MQTTClientComponent::disable_birth_message() {
   this->birth_message_.topic = "";
+  this->birth_message_auto_ = false;
   this->recalculate_availability_();
 }
 void MQTTClientComponent::disable_shutdown_message() {
   this->shutdown_message_.topic = "";
+  this->shutdown_message_auto_ = false;
   this->recalculate_availability_();
 }
 bool MQTTClientComponent::is_discovery_enabled() const { return !this->discovery_info_.prefix.empty(); }
@@ -661,15 +684,20 @@ void MQTTClientComponent::recalculate_availability_() {
 
 void MQTTClientComponent::set_last_will(MQTTMessage &&message) {
   this->last_will_ = std::move(message);
+  this->last_will_auto_ = false;
   this->recalculate_availability_();
 }
 
 void MQTTClientComponent::set_birth_message(MQTTMessage &&message) {
   this->birth_message_ = std::move(message);
+  this->birth_message_auto_ = false;
   this->recalculate_availability_();
 }
 
-void MQTTClientComponent::set_shutdown_message(MQTTMessage &&message) { this->shutdown_message_ = std::move(message); }
+void MQTTClientComponent::set_shutdown_message(MQTTMessage &&message) {
+  this->shutdown_message_ = std::move(message);
+  this->shutdown_message_auto_ = false;
+}
 
 void MQTTClientComponent::set_discovery_info(std::string &&prefix, MQTTDiscoveryUniqueIdGenerator unique_id_generator,
                                              MQTTDiscoveryObjectIdGenerator object_id_generator, bool retain,
@@ -682,7 +710,10 @@ void MQTTClientComponent::set_discovery_info(std::string &&prefix, MQTTDiscovery
   this->discovery_info_.clean = clean;
 }
 
-void MQTTClientComponent::disable_last_will() { this->last_will_.topic = ""; }
+void MQTTClientComponent::disable_last_will() {
+  this->last_will_.topic = "";
+  this->last_will_auto_ = false;
+}
 
 void MQTTClientComponent::disable_discovery() {
   this->discovery_info_ = MQTTDiscoveryInfo{

--- a/esphome/components/mqtt/mqtt_client.h
+++ b/esphome/components/mqtt/mqtt_client.h
@@ -166,7 +166,7 @@ class MQTTClientComponent : public Component {
    *
    * @param topic_prefix The topic prefix. The last "/" is appended automatically.
    */
-  void set_topic_prefix(const std::string &topic_prefix, const std::string &check_topic_prefix);
+  void set_topic_prefix(const std::string &topic_prefix);
   /// Get the topic prefix of this device, using default if necessary
   const std::string &get_topic_prefix() const;
 
@@ -312,6 +312,11 @@ class MQTTClientComponent : public Component {
       .object_id_generator = MQTT_NONE_OBJECT_ID_GENERATOR,
   };
   std::string topic_prefix_{};
+  bool topic_prefix_auto_{true};
+  bool birth_message_auto_{true};
+  bool last_will_auto_{true};
+  bool shutdown_message_auto_{true};
+  bool log_message_auto_{true};
   MQTTMessage log_message_;
   std::string payload_buffer_;
   int log_level_{ESPHOME_LOG_LEVEL};

--- a/esphome/components/mqtt/mqtt_component.cpp
+++ b/esphome/components/mqtt/mqtt_component.cpp
@@ -156,7 +156,11 @@ bool MQTTComponent::send_discovery_() {
         device_info[MQTT_DEVICE_IDENTIFIERS] = mac;
         device_info[MQTT_DEVICE_NAME] = node_friendly_name;
 #ifdef ESPHOME_PROJECT_NAME
+#ifdef JETHOME_MQTT_VERSION
+        device_info[MQTT_DEVICE_SW_VERSION] = ESPHOME_PROJECT_VERSION;
+#else
         device_info[MQTT_DEVICE_SW_VERSION] = ESPHOME_PROJECT_VERSION " (ESPHome " ESPHOME_VERSION ")";
+#endif
         const char *model = std::strchr(ESPHOME_PROJECT_NAME, '.');
         if (model == nullptr) {  // must never happen but check anyway
           device_info[MQTT_DEVICE_MODEL] = ESPHOME_BOARD;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes default MQTT topic prefix and availability/log message initialization behavior, which can alter published topics and HA discovery expectations for existing deployments.
> 
> **Overview**
> Refactors MQTT topic/default-message handling so `topic_prefix`, availability (birth/last-will/shutdown), and log topics are now **auto-generated in `MQTTClientComponent::setup()`** unless explicitly configured/disabled.
> 
> On the YAML side, `topic_prefix` no longer defaults to `CORE.name`, default birth/will/shutdown/log messages are only synthesized when a non-empty `topic_prefix` is provided, and codegen only calls the corresponding setters/disable methods when the user explicitly specifies those options. Separately, Home Assistant discovery `sw_version` formatting is adjusted behind `JETHOME_MQTT_VERSION` to optionally omit the appended ESPHome version string.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e53378a50922f18cc84997bf39228f08fba1622f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->